### PR TITLE
Draw a white background on the graph

### DIFF
--- a/FtcDashboard/dash/src/containers/Graph.js
+++ b/FtcDashboard/dash/src/containers/Graph.js
@@ -196,6 +196,10 @@ export default class Graph {
 
     const width = this.canvas.width / devicePixelRatio;
     const height = this.canvas.height / devicePixelRatio;
+
+    this.ctx.fillStyle = '#fff';
+    this.ctx.fillRect(0, 0, width, height);
+
     const keyHeight = this.renderKey(0, 0, width);
     this.renderGraph(0, keyHeight, width, height - keyHeight);
   }


### PR DESCRIPTION
With the pause feature, it's very convenient to grab samples of the graph. As the graph is a canvas, one can right click and choose copy/save image to download directly from the canvas. Previously, the graph never drew a background. It would result in an image with a transparent background:
 
![Screen Shot 2021-01-03 at 5 38 47 PM](https://user-images.githubusercontent.com/6739076/103491567-8987da80-4dea-11eb-895a-8cb2001537e5.jpg)

Drawing a white rectangle solves this issue:

![Screen Shot 2021-01-03 at 5 39 16 PM](https://user-images.githubusercontent.com/6739076/103491574-9ad0e700-4dea-11eb-8b0c-aa09389160ad.jpg)
