### PR TITLE
Settings middleware fix

### DIFF
--- a/FtcDashboard/dash/src/store/middleware/storageMiddleware.ts
+++ b/FtcDashboard/dash/src/store/middleware/storageMiddleware.ts
@@ -1,7 +1,7 @@
 import { Middleware } from 'redux';
 
 import LayoutPreset, { LayoutPresetType } from '../../enums/LayoutPreset';
-import { GET_LAYOUT_PRESET } from '../types';
+import { GET_LAYOUT_PRESET, SAVE_LAYOUT_PRESET } from '../types';
 import { receiveLayoutPreset } from '../actions/settings';
 import { RootState } from '../reducers';
 
@@ -16,6 +16,13 @@ const storageMiddleware: Middleware<Record<string, unknown>, RootState> = (
         localStorage.getItem(LAYOUT_PRESET_KEY) || LayoutPreset.DEFAULT;
 
       store.dispatch(receiveLayoutPreset(preset as LayoutPresetType));
+
+      break;
+    }
+    case SAVE_LAYOUT_PRESET: {
+      localStorage.setItem(LAYOUT_PRESET_KEY, action.preset);
+
+      store.dispatch(receiveLayoutPreset(action.preset));
 
       break;
     }

--- a/FtcDashboard/dash/src/store/reducers/settings.ts
+++ b/FtcDashboard/dash/src/store/reducers/settings.ts
@@ -1,7 +1,4 @@
-import {
-  SAVE_LAYOUT_PRESET,
-  SaveLayoutPresetAction,
-} from './../types/settings';
+import { SaveLayoutPresetAction } from './../types/settings';
 import LayoutPreset from '../../enums/LayoutPreset';
 
 import {
@@ -20,11 +17,6 @@ const settingsReducer = (
 ) => {
   switch (action.type) {
     case RECEIVE_LAYOUT_PRESET:
-      return {
-        ...state,
-        layoutPreset: action.preset,
-      };
-    case SAVE_LAYOUT_PRESET:
       return {
         ...state,
         layoutPreset: action.preset,

--- a/FtcDashboard/dash/src/store/reducers/settings.ts
+++ b/FtcDashboard/dash/src/store/reducers/settings.ts
@@ -1,4 +1,3 @@
-import { SaveLayoutPresetAction } from './../types/settings';
 import LayoutPreset from '../../enums/LayoutPreset';
 
 import {
@@ -13,7 +12,7 @@ const initialState: SettingState = {
 
 const settingsReducer = (
   state: SettingState = initialState,
-  action: ReceiveLayoutPresetAction | SaveLayoutPresetAction,
+  action: ReceiveLayoutPresetAction,
 ) => {
   switch (action.type) {
     case RECEIVE_LAYOUT_PRESET:

--- a/FtcDashboard/dash/src/store/reducers/settings.ts
+++ b/FtcDashboard/dash/src/store/reducers/settings.ts
@@ -1,3 +1,7 @@
+import {
+  SAVE_LAYOUT_PRESET,
+  SaveLayoutPresetAction,
+} from './../types/settings';
 import LayoutPreset from '../../enums/LayoutPreset';
 
 import {
@@ -12,10 +16,15 @@ const initialState: SettingState = {
 
 const settingsReducer = (
   state: SettingState = initialState,
-  action: ReceiveLayoutPresetAction,
+  action: ReceiveLayoutPresetAction | SaveLayoutPresetAction,
 ) => {
   switch (action.type) {
     case RECEIVE_LAYOUT_PRESET:
+      return {
+        ...state,
+        layoutPreset: action.preset,
+      };
+    case SAVE_LAYOUT_PRESET:
       return {
         ...state,
         layoutPreset: action.preset,


### PR DESCRIPTION
Settings middleware wasn't fully translated during the Typescript conversion. Breaks the layout switcher. 