### PR TITLE
fix windows compile error

### DIFF
--- a/FtcDashboard/dash/.eslintrc.json
+++ b/FtcDashboard/dash/.eslintrc.json
@@ -46,7 +46,12 @@
         "tsx": "never"
       }
     ],
-    "prettier/prettier": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "no-use-before-define": "off",
     "eqeqeq": ["error", "always", { "null": "ignore" }]


### PR DESCRIPTION
Current configuration is not compliable on Windows with default AS/git settings because of different new line format. Pls update lint settings to enable automated handing of cr/lf characters 

```
> Task :FtcDashboard:yarn_build
yarn run v1.22.10
$ craco build
Creating an optimized production build...
Failed to compile.

src\components\AutoFitCanvas.jsx
  Line 1:27:   Delete `�??`  prettier/prettier
  ...
```

