### PR TITLE
Filter graph samples that only contain timestamp

### DIFF
--- a/FtcDashboard/dash/src/containers/GraphCanvas.jsx
+++ b/FtcDashboard/dash/src/containers/GraphCanvas.jsx
@@ -25,7 +25,9 @@ class GraphCanvas extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    this.props.data.forEach((sample) => this.graph.addSample(sample));
+    this.props.data
+      .filter((e) => e.length > 1)
+      .forEach((sample) => this.graph.addSample(sample));
 
     if (prevProps.paused !== this.props.paused) {
       if (this.requestId) cancelAnimationFrame(this.requestId);


### PR DESCRIPTION
Fixes #53

Probably shouldn't have opened the issue. I didn't realize the fix would be so simple.

Issue was caused by the `GraphCanvas` component sending sample data to the graph only containing time stamps without any actual data. Filtering these objects out fixes the issue.