### PR TITLE
Add ignoreDisabled to @Config

### DIFF
--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/config/Config.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/config/Config.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * <p>All public, static, non-final fields of the class will be automatically added as configuration
  * variables in the dashboard. When the user saves new values, these fields are correspondingly
  * updated. Classes annotated with {@link com.qualcomm.robotcore.eventloop.opmode.Disabled} are
- * ignored.
+ * ignored, unless you set {@link #ignoreDisabled} to `true`.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -20,4 +20,9 @@ public @interface Config {
      * Name of this block of configuration variables. Defaults to the class's simple name.
      */
     String value() default "";
+
+    /**
+     * Ignore the @Disabled annotation. Effectively force-enables configuration.
+     */
+    boolean ignoreDisabled() default false;
 }

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
@@ -34,16 +34,22 @@ public class ReflectionConfig {
 
             @Override
             public void processClass(Class<?> configClass) {
-                if (configClass.isAnnotationPresent(Config.class)
-                        && !configClass.isAnnotationPresent(Disabled.class)) {
-                    Log.i(TAG, "Config class: " + configClass.getName());
-                    String name = configClass.getSimpleName();
-                    String altName = configClass.getAnnotation(Config.class).value();
-                    if (!altName.isEmpty()) {
-                        name = altName;
-                    }
+                // I'm doing the check this way because it's technically safer than using
+                //  configClass.isAnnotationPresent(Config.class). It *is* slightly slower, but
+                //  it's on the scale of nanoseconds, so I don't care. ~ryleu
+                Config config = configClass.getAnnotation(Config.class);
+                if (config != null) {
+                    if (!configClass.isAnnotationPresent(Disabled.class)
+                            || config.ignoreDisabled()) {
+                        Log.i(TAG, "Config class: " + configClass.getName());
+                        String name = configClass.getSimpleName();
+                        String altName = config.value();
+                        if (!altName.isEmpty()) {
+                            name = altName;
+                        }
 
-                    configRoot.putVariable(name, createVariableFromClass(configClass));
+                        configRoot.putVariable(name, createVariableFromClass(configClass));
+                    }
                 }
             }
         });


### PR DESCRIPTION
Adds a field in `@Config` that lets you override the `@Disabled` annotation, adding the configuration variables to the dashboard regardless of whether `@Disabled` is present.