### PR TITLE
Fix gamepad axis mapping

### DIFF
--- a/FtcDashboard/dash/src/store/middleware/gamepadMiddleware.ts
+++ b/FtcDashboard/dash/src/store/middleware/gamepadMiddleware.ts
@@ -118,8 +118,8 @@ const extractGamepadState = (gamepad: Gamepad) => {
         // USB ID=24C6, PID=530A
         left_stick_x: cleanMotionValues(gamepad.axes[0]),
         left_stick_y: cleanMotionValues(gamepad.axes[1]),
-        right_stick_x: cleanMotionValues(gamepad.axes[3]),
-        right_stick_y: cleanMotionValues(gamepad.axes[4]),
+        right_stick_x: cleanMotionValues(gamepad.axes[2]),
+        right_stick_y: cleanMotionValues(gamepad.axes[3]),
 
         dpad_up: gamepad.buttons[12].pressed,
         dpad_down: gamepad.buttons[13].pressed,


### PR DESCRIPTION
This issue has been bothering me for a long time and I have decided to open a PR to fix it:
The mapping on our team's controllers in the dashboard was off - left stick axes were mapped correctly but right_stick_x was mapped to the controller's right_stick_y and right_stick_y wasn't being mapped at all. Taking a look at the code, it was simply 2 typos.