### PR TITLE
Fixed linux PS4 dualshock touchpad support

### DIFF
--- a/FtcDashboard/dash/src/store/middleware/gamepadMiddleware.ts
+++ b/FtcDashboard/dash/src/store/middleware/gamepadMiddleware.ts
@@ -144,36 +144,67 @@ const extractGamepadState = (gamepad: Gamepad) => {
         right_trigger: gamepad.buttons[7].value,
       };
     case GamepadType.SONY_DUALSHOCK_4:
-      return {
-        left_stick_x: cleanMotionValues(gamepad.axes[0]),
-        left_stick_y: cleanMotionValues(gamepad.axes[1]),
-        right_stick_x: cleanMotionValues(gamepad.axes[2]),
-        right_stick_y: cleanMotionValues(gamepad.axes[3]),
+      if (gamepad.buttons[17] !== undefined)
+        return {
+          left_stick_x: cleanMotionValues(gamepad.axes[0]),
+          left_stick_y: cleanMotionValues(gamepad.axes[1]),
+          right_stick_x: cleanMotionValues(gamepad.axes[2]),
+          right_stick_y: cleanMotionValues(gamepad.axes[3]),
 
-        dpad_up: gamepad.buttons[12].pressed,
-        dpad_down: gamepad.buttons[13].pressed,
-        dpad_left: gamepad.buttons[14].pressed,
-        dpad_right: gamepad.buttons[15].pressed,
+          dpad_up: gamepad.buttons[12].pressed,
+          dpad_down: gamepad.buttons[13].pressed,
+          dpad_left: gamepad.buttons[14].pressed,
+          dpad_right: gamepad.buttons[15].pressed,
 
-        a: gamepad.buttons[0].pressed,
-        b: gamepad.buttons[1].pressed,
-        x: gamepad.buttons[2].pressed,
-        y: gamepad.buttons[3].pressed,
+          a: gamepad.buttons[0].pressed,
+          b: gamepad.buttons[1].pressed,
+          x: gamepad.buttons[2].pressed,
+          y: gamepad.buttons[3].pressed,
 
-        guide: gamepad.buttons[16].pressed,
-        start: gamepad.buttons[9].pressed,
-        back: gamepad.buttons[8].pressed,
+          guide: gamepad.buttons[16].pressed,
+          start: gamepad.buttons[9].pressed,
+          back: gamepad.buttons[8].pressed,
 
-        left_bumper: gamepad.buttons[4].pressed,
-        right_bumper: gamepad.buttons[5].pressed,
+          left_bumper: gamepad.buttons[4].pressed,
+          right_bumper: gamepad.buttons[5].pressed,
 
-        left_stick_button: gamepad.buttons[10].pressed,
-        right_stick_button: gamepad.buttons[11].pressed,
-        left_trigger: gamepad.buttons[6].value,
-        right_trigger: gamepad.buttons[7].value,
+          left_stick_button: gamepad.buttons[10].pressed,
+          right_stick_button: gamepad.buttons[11].pressed,
+          left_trigger: gamepad.buttons[6].value,
+          right_trigger: gamepad.buttons[7].value,
 
-        touchpad: gamepad.buttons[17].pressed,
-      };
+          touchpad: gamepad.buttons[17].pressed,
+        };
+      else
+        return {
+          left_stick_x: cleanMotionValues(gamepad.axes[0]),
+          left_stick_y: cleanMotionValues(gamepad.axes[1]),
+          right_stick_x: cleanMotionValues(gamepad.axes[2]),
+          right_stick_y: cleanMotionValues(gamepad.axes[3]),
+
+          dpad_up: gamepad.buttons[12].pressed,
+          dpad_down: gamepad.buttons[13].pressed,
+          dpad_left: gamepad.buttons[14].pressed,
+          dpad_right: gamepad.buttons[15].pressed,
+
+          a: gamepad.buttons[0].pressed,
+          b: gamepad.buttons[1].pressed,
+          x: gamepad.buttons[2].pressed,
+          y: gamepad.buttons[3].pressed,
+
+          guide: gamepad.buttons[16].pressed,
+          start: gamepad.buttons[9].pressed,
+          back: gamepad.buttons[8].pressed,
+
+          left_bumper: gamepad.buttons[4].pressed,
+          right_bumper: gamepad.buttons[5].pressed,
+
+          left_stick_button: gamepad.buttons[10].pressed,
+          right_stick_button: gamepad.buttons[11].pressed,
+          left_trigger: gamepad.buttons[6].value,
+          right_trigger: gamepad.buttons[7].value,
+        };
+
     default:
       throw new Error(`Unable to handle support gamepad of type ${type}`);
   }
@@ -182,17 +213,30 @@ const extractGamepadState = (gamepad: Gamepad) => {
 let gamepad1Index = -1;
 let gamepad2Index = -1;
 
-
 const gamepadMiddleware: Middleware<Record<string, unknown>, RootState> = (
   store,
 ) => {
   let getGamepads = navigator.getGamepads?.bind(navigator);
   if (getGamepads == null) {
-    getGamepads = function() { return [null, null, null, null]; }
-    console.log("Gamepads not supported over non-https. See https://developer.mozilla.org/en-US/docs/Web/API/Gamepad");
-    setTimeout(() => { store.dispatch({ type: GAMEPAD_SUPPORTED_STATUS, gamepadsSupported: false }); }, 1000);
+    getGamepads = function () {
+      return [null, null, null, null];
+    };
+    console.log(
+      'Gamepads not supported over non-https. See https://developer.mozilla.org/en-US/docs/Web/API/Gamepad',
+    );
+    setTimeout(() => {
+      store.dispatch({
+        type: GAMEPAD_SUPPORTED_STATUS,
+        gamepadsSupported: false,
+      });
+    }, 1000);
   } else {
-    setTimeout(() => { store.dispatch({ type: GAMEPAD_SUPPORTED_STATUS, gamepadsSupported: true }); }, 1000);
+    setTimeout(() => {
+      store.dispatch({
+        type: GAMEPAD_SUPPORTED_STATUS,
+        gamepadsSupported: true,
+      });
+    }, 1000);
   }
   function updateGamepads() {
     const gamepads = getGamepads();

--- a/FtcDashboard/dash/src/store/middleware/gamepadMiddleware.ts
+++ b/FtcDashboard/dash/src/store/middleware/gamepadMiddleware.ts
@@ -144,39 +144,8 @@ const extractGamepadState = (gamepad: Gamepad) => {
         right_trigger: gamepad.buttons[7].value,
       };
     case GamepadType.SONY_DUALSHOCK_4:
-      if (gamepad.buttons[17] !== undefined)
-        return {
-          left_stick_x: cleanMotionValues(gamepad.axes[0]),
-          left_stick_y: cleanMotionValues(gamepad.axes[1]),
-          right_stick_x: cleanMotionValues(gamepad.axes[2]),
-          right_stick_y: cleanMotionValues(gamepad.axes[3]),
-
-          dpad_up: gamepad.buttons[12].pressed,
-          dpad_down: gamepad.buttons[13].pressed,
-          dpad_left: gamepad.buttons[14].pressed,
-          dpad_right: gamepad.buttons[15].pressed,
-
-          a: gamepad.buttons[0].pressed,
-          b: gamepad.buttons[1].pressed,
-          x: gamepad.buttons[2].pressed,
-          y: gamepad.buttons[3].pressed,
-
-          guide: gamepad.buttons[16].pressed,
-          start: gamepad.buttons[9].pressed,
-          back: gamepad.buttons[8].pressed,
-
-          left_bumper: gamepad.buttons[4].pressed,
-          right_bumper: gamepad.buttons[5].pressed,
-
-          left_stick_button: gamepad.buttons[10].pressed,
-          right_stick_button: gamepad.buttons[11].pressed,
-          left_trigger: gamepad.buttons[6].value,
-          right_trigger: gamepad.buttons[7].value,
-
-          touchpad: gamepad.buttons[17].pressed,
-        };
-      else
-        return {
+      {
+        const state: GamepadState = {
           left_stick_x: cleanMotionValues(gamepad.axes[0]),
           left_stick_y: cleanMotionValues(gamepad.axes[1]),
           right_stick_x: cleanMotionValues(gamepad.axes[2]),
@@ -204,6 +173,12 @@ const extractGamepadState = (gamepad: Gamepad) => {
           left_trigger: gamepad.buttons[6].value,
           right_trigger: gamepad.buttons[7].value,
         };
+        if (gamepad.buttons[17] !== undefined) {
+          state.touchpad = gamepad.buttons[17].pressed;
+        }
+        return state;
+      }
+      break;
 
     default:
       throw new Error(`Unable to handle support gamepad of type ${type}`);


### PR DESCRIPTION
Due to the way linux handles the touchpad of the PS4 DualShock controller(sees it as a pointing device), the gamepad doesn't work. This is a support fix, if the Team Code relies on the touchpad, there is no way to use it from the dashboard. With this fix, the touchpad button is ignored only on linux.