### PR TITLE
Updated the docs for version 0.4.8

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -8,7 +8,7 @@ layout: default
 
 ### Basic
 
-Open `build.dependencies.gradle`. In the `repositories` section add `maven { url = 'https://maven.brott.dev/' }`, and in the `dependencies` section add `implementation 'com.acmerobotics.dashboard:dashboard:0.4.6'`.
+Open `build.dependencies.gradle`. In the `repositories` section add `maven { url = 'https://maven.brott.dev/' }`, and in the `dependencies` section add `implementation 'com.acmerobotics.dashboard:dashboard:0.4.8'`.
 
 Note: If you're using OpenRC or have non-standard SDK dependencies, add the following exclusion.
 ```groovy


### PR DESCRIPTION
The getting started docs say to install 0.4.6 even if 0.4.8 is the latest version

Before issuing a pull request, please see the contributing page.
