### PR TITLE
Add array config support

### DIFF
--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ArrayProvider.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ArrayProvider.java
@@ -1,0 +1,37 @@
+package com.acmerobotics.dashboard.config.reflection;
+
+import com.acmerobotics.dashboard.config.ValueProvider;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+
+public class ArrayProvider<T> implements ValueProvider<T> {
+    private final Field field;
+    private final Object parent;
+    private final int index;
+    public ArrayProvider(Field field, Object parent, int index) {
+        this.field = field;
+        this.parent = parent;
+        this.index = index;
+    }
+    @SuppressWarnings("unchecked")
+    @Override
+    public T get() {
+        try {
+            return (T) Array.get(field.get(parent),index);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch(ArrayIndexOutOfBoundsException e)
+        {
+            return null;
+        }
+    }
+    @Override
+    public void set(T value) {
+        try {
+            Array.set(field.get(parent),index, value);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }catch(ArrayIndexOutOfBoundsException ignored) { }
+    }
+}

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ArrayProvider.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ArrayProvider.java
@@ -8,17 +8,17 @@ import java.lang.reflect.Field;
 public class ArrayProvider<T> implements ValueProvider<T> {
     private final Field field;
     private final Object parent;
-    private final int index;
-    public ArrayProvider(Field field, Object parent, int index) {
+    private final int[] indices;
+    public ArrayProvider(Field field, Object parent, int... indices) {
         this.field = field;
         this.parent = parent;
-        this.index = index;
+        this.indices = indices;
     }
     @SuppressWarnings("unchecked")
     @Override
     public T get() {
         try {
-            return (T) Array.get(field.get(parent),index);
+            return (T) getArrayRecursive(field.get(parent), indices);
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         } catch(ArrayIndexOutOfBoundsException e)
@@ -29,9 +29,26 @@ public class ArrayProvider<T> implements ValueProvider<T> {
     @Override
     public void set(T value) {
         try {
-            Array.set(field.get(parent),index, value);
+            setArrayRecursive(field.get(parent), value, indices);
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }catch(ArrayIndexOutOfBoundsException ignored) { }
+    }
+
+
+    public static Object getArrayRecursive(Object object, int[] indices) throws ArrayIndexOutOfBoundsException, IllegalAccessException
+    {
+        for (int index : indices) {
+            object = Array.get(object, index);
+        }
+        return object;
+    }
+    public static void setArrayRecursive(Object object, Object value, int[] indices)
+    {
+        for(int i=0;i< indices.length-1;i++)
+        {
+            object=Array.get(object,indices[i]);
+        }
+        Array.set(object,indices[indices.length-1], value);
     }
 }

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
@@ -5,6 +5,7 @@ import com.acmerobotics.dashboard.config.variable.ConfigVariable;
 import com.acmerobotics.dashboard.config.variable.CustomVariable;
 import com.acmerobotics.dashboard.config.variable.VariableType;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
@@ -24,7 +25,50 @@ public class ReflectionConfig {
 
         return customVariable;
     }
+    private static ConfigVariable<?>  createVariableFromArrayField(Field field, Object parent, int index) {
+        Class<?> fieldClass = field.getType().getComponentType();
+        VariableType type = VariableType.fromClass(fieldClass);
+        switch (type) {
+            case BOOLEAN:
+            case INT:
+            case DOUBLE:
+            case STRING:
+            case ENUM:
+                return new BasicVariable<>(type, new ArrayProvider<Boolean>(field, parent,index));
+            case CUSTOM:
+                try {
+                    Object value = Array.get(field.get(parent), index);
+                    if (value == null) {
+                        return new CustomVariable(null);
+                    }
+                    CustomVariable customVariable = new CustomVariable();
+                    if(fieldClass.isArray())
+                    {
+                        for(int i = 0; i<Array.getLength(value); i++)
+                        {
+                            customVariable.putVariable(Integer.toString(i), createVariableFromArrayField(field, parent, i));
+                        }
+                    }
+                    else {
+                        for (Field nestedField : fieldClass.getFields()) {
+                            if (Modifier.isFinal(field.getModifiers())) {
+                                continue;
+                            }
 
+                            String name = nestedField.getName();
+                            customVariable.putVariable(name,
+                                    createVariableFromField(nestedField, value));
+                        }
+                    }
+                    return customVariable;
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            default:
+                throw new RuntimeException("Unsupported field type: " +
+                        fieldClass.getName());
+        }
+    }
     private static ConfigVariable<?> createVariableFromField(Field field, Object parent) {
         Class<?> fieldClass = field.getType();
         VariableType type = VariableType.fromClass(fieldClass);
@@ -41,18 +85,25 @@ public class ReflectionConfig {
                     if (value == null) {
                         return new CustomVariable(null);
                     }
-
                     CustomVariable customVariable = new CustomVariable();
-                    for (Field nestedField : fieldClass.getFields()) {
-                        if (Modifier.isFinal(field.getModifiers())) {
-                            continue;
+                    if(fieldClass.isArray())
+                    {
+                        for(int i = 0; i<Array.getLength(value); i++)
+                        {
+                            customVariable.putVariable(Integer.toString(i), createVariableFromArrayField(field, parent, i));
                         }
-
-                        String name = nestedField.getName();
-                        customVariable.putVariable(name,
-                                createVariableFromField(nestedField, value));
                     }
+                    else {
+                        for (Field nestedField : fieldClass.getFields()) {
+                            if (Modifier.isFinal(field.getModifiers())) {
+                                continue;
+                            }
 
+                            String name = nestedField.getName();
+                            customVariable.putVariable(name,
+                                    createVariableFromField(nestedField, value));
+                        }
+                    }
                     return customVariable;
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException(e);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/ArrayTestOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/ArrayTestOpMode.java
@@ -1,0 +1,34 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+@SuppressWarnings("unused")
+@Config
+@TeleOp
+public class ArrayTestOpMode extends LinearOpMode {
+    public static class NestedClass {
+        public int a,b;
+    }
+    public static int[] array = new int[3];
+    public static NestedClass[] innerArray = new NestedClass[] { new NestedClass(), new NestedClass(), new NestedClass()};
+    @Override
+    public void runOpMode() {
+        telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
+
+        waitForStart();
+        array=new int[2];
+        while(opModeIsActive())
+        {
+            telemetry.addData("array0", array[0]);
+            telemetry.addData("array1", array[1]);
+            telemetry.addData("innerArray0A", innerArray[0].a);
+            telemetry.addData("innerArray1B", innerArray[1].b);
+            telemetry.addData("innerArray2A", innerArray[2].a);
+            telemetry.update();
+        }
+    }
+}


### PR DESCRIPTION
As it says, this config adds the ability to edit array values in the Config window of the dashboard. This is achieved by using different ValueProvider implementation(which accesses the values from the array) when creating nested CustomVariables, and using indices as the names for those variables.
This modification is safe, since resizing the array doesn't cause any exceptions, but should ideally somehow cause a refresh of the config variables.