### PR TITLE
Rewrite the camera section of documentation

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ layout: default
 
 ## Telemetry
 
-FTC apps keep the dashboard updated through periodic telemetry transmissions. Telemetry packets contain text key-value pairs like the provided SDK interfaces. They also store graphics to be displayed over the field image. 
+FTC apps keep the dashboard updated through periodic telemetry transmissions. Telemetry packets contain text key-value pairs like the provided SDK interfaces. They also store graphics to be displayed over the field image.
 
 Packets have a map-like interface for adding unstructured data.
 
@@ -26,14 +26,14 @@ packet.fieldOverlay()
 
 Check out [this page](fieldview) for more information on Field View drawing.
 
-Use `FtcDashboard#sendTelemetryPacket()` to dispatch complete packets. 
+Use `FtcDashboard#sendTelemetryPacket()` to dispatch complete packets.
 
 ```java
 FtcDashboard dashboard = FtcDashboard.getInstance();
 dashboard.sendTelemetryPacket(packet);
 ```
 
-For convenience, the dashboard offers a restricted implementation of `Telemetry`. 
+For convenience, the dashboard offers a restricted implementation of `Telemetry`.
 
 ```java
 FtcDashboard dashboard = FtcDashboard.getInstance();
@@ -62,7 +62,7 @@ public class MultipleTelemetryExampleOpMode extends OpMode {
 
 ## Configuration Variables
 
-Configuration variables are special fields that the dashboard client can seamlessly modify while the app is running. To mark a field as a config variable, declare it `static` and not `final` and annotate the enclosing class with `@Config`. 
+Configuration variables are special fields that the dashboard client can seamlessly modify while the app is running. To mark a field as a config variable, declare it `static` and not `final` and annotate the enclosing class with `@Config`.
 
 ```java
 @Config
@@ -109,9 +109,9 @@ public class StaleServoOpMode extends LinearOpMode {
 }
 ```
 
-The value of `SERVO_POS_OFFSET` is read once at the start of the op mode to pass to the `ServoArm` constructor. The field `posOffset` gets an independent copy of `SERVO_POS_OFFSET`; it only gets the new `SERVO_POS_OFFSET` when the op mode is reinitialized. 
+The value of `SERVO_POS_OFFSET` is read once at the start of the op mode to pass to the `ServoArm` constructor. The field `posOffset` gets an independent copy of `SERVO_POS_OFFSET`; it only gets the new `SERVO_POS_OFFSET` when the op mode is reinitialized.
 
-With some slight adjustments, position offset modifications can appear truly live, 
+With some slight adjustments, position offset modifications can appear truly live,
 
 ```java
 @Config
@@ -149,19 +149,25 @@ Config variable declarations in Kotlin are cumbersome but still possible with `@
 
 ```kotlin
 @Config
-object RobotConstants {  
+object RobotConstants {
     @JvmField var MAGIC_NUMBER = 32
     @JvmField var TURNING_PID = PIDCoefficients()
     // other constants
 }
 ```
 
-## Op Mode Controls 
+## Op Mode Controls
 
-Op mode controls replicate limited DS functionality. Some gamepads are supported for testing in a pinch. Plug them in and press Start-A/B as usual to activate. Dashboard gamepads will have higher latency and less robustness than DS ones and should be used accordingly. Safety mechanisms attempt to stop the robot if gamepads spontaneously disconnect, but there are no guarantees. 
+Op mode controls replicate limited DS functionality. Some gamepads are supported for testing in a pinch. Plug them in and press Start-A/B as usual to activate. Dashboard gamepads will have higher latency and less robustness than DS ones and should be used accordingly. Safety mechanisms attempt to stop the robot if gamepads spontaneously disconnect, but there are no guarantees.
 
 ## Camera
 
-The camera view can show a live camera stream as demonstrated in [this op mode](https://github.com/acmerobotics/ftc-dashboard/blob/master/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/VuforiaStreamOpMode.java). In brief, use a call like `FtcDashboard.getInstance().startCameraStream(camera, 0);` where `camera` implements `CameraStreamSource`. 
+Teams may be interested in previewing the two different vision systems, vision portal and traditional EasyOpenCV. The vision portal API was introduced in CenterStage 2023-2024 and it's usage with FTC dashboard is documented [in this op mode](https://github.com/acmerobotics/ftc-dashboard/blob/master/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/VisionPortalStreamingOpMode.java).
 
-Note: The current server interacts poorly with EasyOpenCV camera V1's implementation of `CameraStreamSource`. Stick with the camera V2 or webcam driver to avoid issues. 
+It is also possible to use traditional EasyOpenCV, using a call like `FtcDashboard.getInstance().startCameraStream(camera, 0);` where `camera` implements `CameraStreamSource`. In EasyOpenCV, this camera will be the same one you initialize with the code below.
+
+```java
+int cameraMonitorViewId = hardwareMap.appContext.getResources().getIdentifier("cameraMonitorViewId", "id", hardwareMap.appContext.getPackageName());
+OpenCvWebcam camera = OpenCvCameraFactory.getInstance().createWebcam(hardwareMap.get(WebcamName.class, "Webcam 1"), cameraMonitorViewId);
+FtcDashboard.getInstance().startCameraStream(camera, 0);
+```


### PR DESCRIPTION
Updated for Vision Portal and put a bit more of a description for traditional EasyOpenCV support.

Looks like the line endings got a bit messed up, perhaps one of you could format it with your preferences?