### PR TITLE
Add support for more primitives

### DIFF
--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
@@ -33,6 +33,7 @@ public class ReflectionConfig {
         switch (type) {
             case BOOLEAN:
             case INT:
+            case LONG:
             case DOUBLE:
             case STRING:
             case ENUM:
@@ -88,6 +89,7 @@ public class ReflectionConfig {
         switch (type) {
             case BOOLEAN:
             case INT:
+            case LONG:
             case DOUBLE:
             case STRING:
             case ENUM:

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/reflection/ReflectionConfig.java
@@ -34,6 +34,7 @@ public class ReflectionConfig {
             case BOOLEAN:
             case INT:
             case LONG:
+            case FLOAT:
             case DOUBLE:
             case STRING:
             case ENUM:
@@ -90,6 +91,7 @@ public class ReflectionConfig {
             case BOOLEAN:
             case INT:
             case LONG:
+            case FLOAT:
             case DOUBLE:
             case STRING:
             case ENUM:

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/ConfigVariableDeserializer.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/ConfigVariableDeserializer.java
@@ -25,6 +25,9 @@ public class ConfigVariableDeserializer implements JsonDeserializer<ConfigVariab
             case INT:
                 return new BasicVariable<>(varType,
                     new ConstantProvider<>(valueEl.isJsonNull() ? null : valueEl.getAsInt()));
+            case LONG:
+                return new BasicVariable<>(varType,
+                    new ConstantProvider<>(valueEl.isJsonNull() ? null : valueEl.getAsLong()));
             case DOUBLE:
                 return new BasicVariable<>(varType,
                     new ConstantProvider<>(valueEl.isJsonNull() ? null : valueEl.getAsDouble()));

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/ConfigVariableDeserializer.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/ConfigVariableDeserializer.java
@@ -28,6 +28,9 @@ public class ConfigVariableDeserializer implements JsonDeserializer<ConfigVariab
             case LONG:
                 return new BasicVariable<>(varType,
                     new ConstantProvider<>(valueEl.isJsonNull() ? null : valueEl.getAsLong()));
+            case FLOAT:
+                return new BasicVariable<>(varType,
+                    new ConstantProvider<>(valueEl.isJsonNull() ? null : valueEl.getAsFloat()));
             case DOUBLE:
                 return new BasicVariable<>(varType,
                     new ConstantProvider<>(valueEl.isJsonNull() ? null : valueEl.getAsDouble()));

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/VariableType.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/VariableType.java
@@ -12,6 +12,9 @@ public enum VariableType {
     @SerializedName("int")
     INT,
 
+    @SerializedName("long")
+    LONG,
+
     @SerializedName("double")
     DOUBLE,
 
@@ -34,6 +37,8 @@ public enum VariableType {
             return BOOLEAN;
         } else if (klass == Integer.class || klass == int.class) {
             return INT;
+        } else if (klass == Long.class || klass == long.class) {
+            return LONG;
         } else if (klass == Double.class || klass == double.class) {
             return DOUBLE;
         } else if (klass == String.class) {

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/VariableType.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/config/variable/VariableType.java
@@ -15,6 +15,9 @@ public enum VariableType {
     @SerializedName("long")
     LONG,
 
+    @SerializedName("float")
+    FLOAT,
+
     @SerializedName("double")
     DOUBLE,
 
@@ -39,6 +42,8 @@ public enum VariableType {
             return INT;
         } else if (klass == Long.class || klass == long.class) {
             return LONG;
+        } else if (klass == Float.class || klass == float.class) {
+            return FLOAT;
         } else if (klass == Double.class || klass == double.class) {
             return DOUBLE;
         } else if (klass == String.class) {

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -175,6 +175,7 @@ public class TestDashboardInstance {
                 te = value;
             }
         });
+
         core.addConfigVariable("More Primitives", "Long", new ValueProvider<Long>() {
             private long value = 10L;
 
@@ -185,6 +186,19 @@ public class TestDashboardInstance {
 
             @Override
             public void set(Long value) {
+                this.value = value;
+            }
+        });
+        core.addConfigVariable("More Primitives", "Float", new ValueProvider<Float>() {
+            private float value = 10L;
+
+            @Override
+            public Float get() {
+                return this.value;
+            }
+
+            @Override
+            public void set(Float value) {
                 this.value = value;
             }
         });

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -175,7 +175,19 @@ public class TestDashboardInstance {
                 te = value;
             }
         });
+        core.addConfigVariable("More Primitives", "Long", new ValueProvider<Long>() {
+            private long value = 10L;
 
+            @Override
+            public Long get() {
+                return this.value;
+            }
+
+            @Override
+            public void set(Long value) {
+                this.value = value;
+            }
+        });
 
         try {
             server.start();

--- a/FtcDashboard/dash/src/components/views/ConfigView/BasicVariable.tsx
+++ b/FtcDashboard/dash/src/components/views/ConfigView/BasicVariable.tsx
@@ -61,6 +61,7 @@ class BasicVariable extends React.Component<Props> {
     } else {
       switch (state.__type) {
         case 'int':
+        case 'long':
           input = (
             <TextInput
               id={path}

--- a/FtcDashboard/dash/src/components/views/ConfigView/BasicVariable.tsx
+++ b/FtcDashboard/dash/src/components/views/ConfigView/BasicVariable.tsx
@@ -73,6 +73,7 @@ class BasicVariable extends React.Component<Props> {
             />
           );
           break;
+        case 'float':
         case 'double':
           if (typeof state.__value === 'string') {
             input = <p>{state.__value}</p>;

--- a/FtcDashboard/dash/src/store/types/config.ts
+++ b/FtcDashboard/dash/src/store/types/config.ts
@@ -20,7 +20,7 @@ export type BasicVar =
       __enumValues: string[];
     }
   | {
-      __type: 'boolean' | 'int' | 'long' | 'double' | 'string';
+      __type: 'boolean' | 'int' | 'long' | 'float' | 'double' | 'string';
       __value: boolean | number | string | null;
     };
 
@@ -33,7 +33,7 @@ export type BasicVarState = (
       __enumValues: string[];
     }
   | {
-      __type: 'boolean' | 'int' | 'long' | 'double' | 'string';
+      __type: 'boolean' | 'int' | 'long' | 'float' | 'double' | 'string';
       __value: boolean | number | string | null;
       __newValue: boolean | number | string | null;
     }

--- a/FtcDashboard/dash/src/store/types/config.ts
+++ b/FtcDashboard/dash/src/store/types/config.ts
@@ -20,7 +20,7 @@ export type BasicVar =
       __enumValues: string[];
     }
   | {
-      __type: 'boolean' | 'int' | 'double' | 'string';
+      __type: 'boolean' | 'int' | 'long' | 'double' | 'string';
       __value: boolean | number | string | null;
     };
 
@@ -33,7 +33,7 @@ export type BasicVarState = (
       __enumValues: string[];
     }
   | {
-      __type: 'boolean' | 'int' | 'double' | 'string';
+      __type: 'boolean' | 'int' | 'long' | 'double' | 'string';
       __value: boolean | number | string | null;
       __newValue: boolean | number | string | null;
     }


### PR DESCRIPTION
This is a draft PR that adds support for more Java primitive types. Closes #148.

# Todo

- [x] `long`
- [x] `float`

# Optional

- [ ] `short`
- [ ] `byte`
- [ ] `char`