### PR TITLE
Add public getter for if the dashboard is active

### DIFF
--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -167,6 +167,11 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
         return instance;
     }
 
+    /**
+     * @return a boolean indicating if the dashboard is currently active
+     */
+    public boolean isEnabled() { return core.enabled; }
+
     private DashboardCore core = new DashboardCore();
 
     private NanoWSD server = new NanoWSD(8000) {


### PR DESCRIPTION
(First time making a PR, so please let me know if I made a mistake somewhere/should change something.)

This is just a simple change to let users check if the dashboard is enabled from code. One use case, and the situation I found myself wanting this for, is to allow selective disabling of elements which are designed for testing and are useless without the dashboard (specifically, a custom speed setting for tuning set within the web interface). However, I'm sure there are other potential use cases.