### PR TITLE
Ensure op mode name for logging does not get overwritten by $Stop$Robot

### DIFF
--- a/client/src/components/views/LoggingView/LoggingView.tsx
+++ b/client/src/components/views/LoggingView/LoggingView.tsx
@@ -199,7 +199,7 @@ const LoggingView = ({
   }, [activeOpMode, activeOpModeStatus, isRecording, opModeList, telemetry]);
 
   useEffect(() => {
-    if (activeOpModeStatus === OpModeStatus.RUNNING) {
+    if (activeOpModeStatus === OpModeStatus.RUNNING && activeOpMode !== STOP_OP_MODE_TAG) {
       setCurrentOpModeName(activeOpMode ?? '');
     }
   }, [activeOpMode, activeOpModeStatus]);


### PR DESCRIPTION
When using the logging view to save a CSV, the file name always starts with `$Stop$Robot` no matter which op mode was run.

This PR ensures that the name of the current op mode for the logging view does not get overwritten by `$Stop$Robot`.

Last downloaded file in this screenshot is after the change, previous ones are before.
![image](https://github.com/user-attachments/assets/2dea6c5e-8eeb-485c-87e8-bed54772de21)
