### PR TITLE
Mirror data sent through the Dashboard to the Driver Station

### DIFF
--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/telemetry/TelemetryPacket.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/telemetry/TelemetryPacket.java
@@ -67,6 +67,13 @@ public class TelemetryPacket {
     }
 
     /**
+     * Returns all telemetry within the log, sorted.
+     */
+    public Map<String, String> getAll(){
+        return data;
+    }
+
+    /**
      * Adds a line to the telemetry log.
      *
      * @param line


### PR DESCRIPTION
This PR adds the ability for the Dashboard to automatically send data to the Driver Station through the user's OpMode Telemetry object. By default this behavior is opt-out, but it could easily be made opt-in if that is seen as necessary. It also supports clearing the DS and changing the transmission interval.

The primary advantage I see here is code deduplication/simplification for the end-user. Right now to provide data to both areas, you must either call each function separately with the same data, or build utility methods to do it for you. Because that is something that can be easily simplified on this end, I think this is a good change to make.

Because (in my understanding) transmission to the Driver Station in this context is always legal, transmission occurs even when the web interface is disabled, allowing this method to be used during competition.

I've not yet tested this on actual hardware, but I plan to do so tomorrow. In the meantime, feedback would be appreciated. :)