### PR TITLE
Add ability to switch the current hardware configuration from the web

### DIFF
--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/MessageType.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/MessageType.java
@@ -5,11 +5,13 @@ import com.acmerobotics.dashboard.message.redux.GetRobotStatus;
 import com.acmerobotics.dashboard.message.redux.InitOpMode;
 import com.acmerobotics.dashboard.message.redux.ReceiveConfig;
 import com.acmerobotics.dashboard.message.redux.ReceiveGamepadState;
+import com.acmerobotics.dashboard.message.redux.ReceiveHardwareConfigList;
 import com.acmerobotics.dashboard.message.redux.ReceiveImage;
 import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
 import com.acmerobotics.dashboard.message.redux.ReceiveTelemetry;
 import com.acmerobotics.dashboard.message.redux.SaveConfig;
+import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.message.redux.StartOpMode;
 import com.acmerobotics.dashboard.message.redux.StopOpMode;
 
@@ -39,7 +41,11 @@ public enum MessageType {
     RECEIVE_IMAGE(ReceiveImage.class),
 
     /* gamepad */
-    RECEIVE_GAMEPAD_STATE(ReceiveGamepadState.class);
+    RECEIVE_GAMEPAD_STATE(ReceiveGamepadState.class),
+
+    /* hardware config */
+    RECEIVE_HARDWARE_CONFIG_LIST(ReceiveHardwareConfigList.class),
+    SET_HARDWARE_CONFIG(SetHardwareConfig.class);
 
     final Class<? extends Message> msgClass;
 

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/ReceiveHardwareConfigList.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/ReceiveHardwareConfigList.java
@@ -1,0 +1,18 @@
+package com.acmerobotics.dashboard.message.redux;
+
+import com.acmerobotics.dashboard.message.Message;
+import com.acmerobotics.dashboard.message.MessageType;
+
+import java.util.List;
+
+public class ReceiveHardwareConfigList extends Message {
+    private List<String> hardwareConfigList;
+    private String currentHardwareConfig;
+
+    public ReceiveHardwareConfigList(List<String> hardwareConfigList, String currentHardwareConfig){
+        super(MessageType.RECEIVE_HARDWARE_CONFIG_LIST);
+
+        this.hardwareConfigList = hardwareConfigList;
+        this.currentHardwareConfig = currentHardwareConfig;
+    }
+}

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/SetHardwareConfig.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/SetHardwareConfig.java
@@ -1,0 +1,18 @@
+package com.acmerobotics.dashboard.message.redux;
+
+import com.acmerobotics.dashboard.message.Message;
+import com.acmerobotics.dashboard.message.MessageType;
+
+public class SetHardwareConfig extends Message {
+    private String hardwareConfigName;
+
+    public SetHardwareConfig(String hardwareConfigName){
+        super(MessageType.SET_HARDWARE_CONFIG);
+
+        this.hardwareConfigName = hardwareConfigName;
+    }
+
+    public String getHardwareConfigName() {
+        return hardwareConfigName;
+    }
+}

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -121,6 +121,13 @@ public class TestDashboardInstance {
                 case SET_HARDWARE_CONFIG:
                     SetHardwareConfig setHardwareConfig = (SetHardwareConfig) msg;
                     hardwareConfigManager.setHardwareConfig(setHardwareConfig.getHardwareConfigName());
+
+                    // In the testing instance we must resend this data manually or things will get out of sync.
+                    // In a live environment the restart will cause this data to be resent automatically.
+                    send(new ReceiveHardwareConfigList(
+                            hardwareConfigManager.getTestHardwareConfigs(),
+                            hardwareConfigManager.getActiveHardwareConfig()
+                    ));
                     break;
                 default:
                     System.out.println(msg.getType());

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -3,8 +3,10 @@ package com.acmerobotics.dashboard;
 import com.acmerobotics.dashboard.config.ValueProvider;
 import com.acmerobotics.dashboard.message.Message;
 import com.acmerobotics.dashboard.message.redux.InitOpMode;
+import com.acmerobotics.dashboard.message.redux.ReceiveHardwareConfigList;
 import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
+import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
 import com.acmerobotics.dashboard.testopmode.TestOpMode;
 import com.acmerobotics.dashboard.testopmode.TestOpModeManager;
@@ -24,6 +26,7 @@ public class TestDashboardInstance {
 
     final String DEFAULT_OP_MODE_NAME = "$Stop$Robot$";
     TestOpModeManager opModeManager = new TestOpModeManager();
+    TestRobotConfigManager hardwareConfigManager = new TestRobotConfigManager();
 
     private TelemetryPacket currentPacket;
 
@@ -63,6 +66,10 @@ public class TestDashboardInstance {
                     .getTestOpModes()
                     .stream().map(TestOpMode::getName)
                     .collect(Collectors.toList())
+            ));
+            send(new ReceiveHardwareConfigList(
+                hardwareConfigManager.getTestHardwareConfigs(),
+                hardwareConfigManager.getActiveHardwareConfig()
             ));
         }
 
@@ -110,6 +117,10 @@ public class TestDashboardInstance {
                     break;
                 case STOP_OP_MODE:
                     opModeManager.stopOpMode();
+                    break;
+                case SET_HARDWARE_CONFIG:
+                    SetHardwareConfig setHardwareConfig = (SetHardwareConfig) msg;
+                    hardwareConfigManager.setHardwareConfig(setHardwareConfig.getHardwareConfigName());
                     break;
                 default:
                     System.out.println(msg.getType());

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestRobotConfigManager.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestRobotConfigManager.java
@@ -1,0 +1,22 @@
+package com.acmerobotics.dashboard;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TestRobotConfigManager {
+    private final List<String> testHardwareConfigs =
+            Arrays.asList("Config One", "Config Two", "Default");
+    private String activeOpMode = "Default";
+
+    public List<String> getTestHardwareConfigs() {
+        return testHardwareConfigs;
+    }
+
+    public String getActiveHardwareConfig() {
+        return activeOpMode;
+    }
+
+    public void setHardwareConfig(String hardwareConfigName) {
+        if(testHardwareConfigs.contains(hardwareConfigName)) activeOpMode = hardwareConfigName;
+    }
+}

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestRobotConfigManager.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestRobotConfigManager.java
@@ -17,6 +17,8 @@ public class TestRobotConfigManager {
     }
 
     public void setHardwareConfig(String hardwareConfigName) {
-        if(testHardwareConfigs.contains(hardwareConfigName)) activeOpMode = hardwareConfigName;
+        if(testHardwareConfigs.contains(hardwareConfigName)) {
+            activeOpMode = hardwareConfigName;
+        }
     }
 }

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -667,12 +667,14 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
 
                     activeOpMode.with(o -> {
                         // Don't allow changing the config unless stopped. Who knows what undefined behavior that would cause
-                       if(o.status != RobotStatus.OpModeStatus.STOPPED) return;
+                       if(o.status != RobotStatus.OpModeStatus.STOPPED &&
+                               !opModeManager.getActiveOpModeName().equals("$Stop$Robot$")) return;
 
                        hardwareConfigList.with(l -> {
                            hardwareConfigManager.setActiveConfig(false, l.get(hardwareConfigName));
                        });
                     });
+                    break;
                 }
                 default: {
                     Log.w(TAG, "Received unknown message of type " + msg.getType());

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -53,8 +53,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -217,7 +217,7 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
     private LinearLayout parentLayout;
 
     private RobotConfigFileManager hardwareConfigManager = new RobotConfigFileManager();
-    private final Mutex<Map<String, RobotConfigFile>> hardwareConfigList = new Mutex<>(new TreeMap<>());
+    private final Mutex<SortedMap<String, RobotConfigFile>> hardwareConfigList = new Mutex<>(new TreeMap<>());
 
     private static class OpModeAndStatus {
         public OpMode opMode;
@@ -670,7 +670,9 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                     activeOpMode.with(o -> {
                         // Don't allow changing the config unless stopped. Who knows what undefined behavior that would cause
                        if(o.status != RobotStatus.OpModeStatus.STOPPED &&
-                               !opModeManager.getActiveOpModeName().equals("$Stop$Robot$")) return;
+                               !opModeManager.getActiveOpModeName().equals(OpModeManager.DEFAULT_OP_MODE_NAME)) {
+                           return;
+                       }
 
                        hardwareConfigList.with(l -> {
                            hardwareConfigManager.setActiveConfig(false, l.get(hardwareConfigName));

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -677,30 +677,29 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                        hardwareConfigList.with(l -> {
                            hardwareConfigManager.setActiveConfig(false, l.get(hardwareConfigName));
                        });
+
+                        // Soft-restart to allow the new config to take effect
+                        // This is admittedly pretty sketchy so we'll do it in a try/catch
+                        try {
+                            // We can't just cast this to FtcRobotControllerActivity because that would create a dependency
+                            Activity robotControllerActivity = AppUtil.getInstance().getRootActivity();
+                            // When called, this method has the ability to perform a restart
+                            Method selectedMethod = robotControllerActivity.getClass().getMethod("onOptionsItemSelected", MenuItem.class);
+
+                            int id = robotControllerActivity.getResources().getIdentifier("action_restart_robot", "id", "com.qualcomm.ftcrobotcontroller");
+
+                            // Spoofs the MenuItem parameter to imitate a restart button-press
+                            MenuItem item = (MenuItem) Proxy.newProxyInstance(
+                                    MenuItem.class.getClassLoader(),
+                                    new Class<?>[] { MenuItem.class },
+                                    (proxy, method, args) -> "getItemId".equals(method.getName()) ? id : null
+                            );
+
+                            selectedMethod.invoke(robotControllerActivity, item);
+                        } catch (Exception e){
+                            RobotLog.ww(TAG, "Something went wrong when reflecting to restart the robot.");
+                        }
                     });
-
-                    // Soft-restart to allow the new config to take effect
-                    // This is admittedly pretty sketchy so we'll do it in a try/catch
-                    try {
-                        // We can't just cast this to FtcRobotControllerActivity because that would create a dependency
-                        Activity robotControllerActivity = AppUtil.getInstance().getRootActivity();
-                        // When called, this method has the ability to perform a restart
-                        Method selectedMethod = robotControllerActivity.getClass().getMethod("onOptionsItemSelected", MenuItem.class);
-
-                        int id = robotControllerActivity.getResources().getIdentifier("action_restart_robot", "id", "com.qualcomm.ftcrobotcontroller");
-
-                        // Spoofs the MenuItem parameter to imitate a restart button-press
-                        MenuItem item = (MenuItem) Proxy.newProxyInstance(
-                                MenuItem.class.getClassLoader(),
-                                new Class<?>[] { MenuItem.class },
-                                (proxy, method, args) -> "getItemId".equals(method.getName()) ? id : null
-                        );
-
-                        selectedMethod.invoke(robotControllerActivity, item);
-                    } catch (Exception e){
-                        RobotLog.ww(TAG, "Something went wrong when reflecting to restart the robot.");
-                    }
-
                     break;
                 }
                 default: {

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -20,11 +20,14 @@ import com.acmerobotics.dashboard.config.variable.CustomVariable;
 import com.acmerobotics.dashboard.message.Message;
 import com.acmerobotics.dashboard.message.redux.InitOpMode;
 import com.acmerobotics.dashboard.message.redux.ReceiveGamepadState;
+import com.acmerobotics.dashboard.message.redux.ReceiveHardwareConfigList;
 import com.acmerobotics.dashboard.message.redux.ReceiveImage;
 import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
+import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
 import com.qualcomm.ftccommon.FtcEventLoop;
+import com.qualcomm.ftccommon.configuration.RobotConfigFile;
 import com.qualcomm.hardware.lynx.LynxModule;
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
@@ -37,6 +40,7 @@ import com.qualcomm.robotcore.util.RobotLog;
 import com.qualcomm.robotcore.util.ThreadPool;
 import com.qualcomm.robotcore.util.WebHandlerManager;
 import com.qualcomm.robotcore.util.WebServer;
+import com.qualcomm.ftccommon.configuration.RobotConfigFileManager;
 import dalvik.system.DexFile;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoWSD;
@@ -47,7 +51,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import org.firstinspires.ftc.ftccommon.external.OnCreate;
@@ -208,6 +214,9 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
     private TextView connectionStatusTextView;
     private LinearLayout parentLayout;
 
+    private RobotConfigFileManager hardwareConfigManager = new RobotConfigFileManager();
+    private final Mutex<Map<String, RobotConfigFile>> hardwareConfigList = new Mutex<>(new TreeMap<>());
+
     private static class OpModeAndStatus {
         public OpMode opMode;
         public RobotStatus.OpModeStatus status = RobotStatus.OpModeStatus.STOPPED;
@@ -252,6 +261,22 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                 }
                 Collections.sort(l);
                 sendAll(new ReceiveOpModeList(l));
+            });
+        }
+    }
+
+    private class ListHardwareConfigsRunnable implements Runnable {
+        @Override
+        public void run(){
+            hardwareConfigList.with(l -> {
+                l.clear();
+                for (RobotConfigFile file : hardwareConfigManager.getXMLFiles()){
+                    l.put(file.getName(), file);
+                }
+                sendAll(new ReceiveHardwareConfigList(
+                        new ArrayList<>(l.keySet()),
+                        hardwareConfigManager.getActiveConfig().getName()
+                ));
             });
         }
     }
@@ -585,6 +610,15 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                 }
             });
 
+            hardwareConfigList.with(l -> {
+                if (!l.isEmpty()){
+                    send(new ReceiveHardwareConfigList(
+                            new ArrayList<>(l.keySet()),
+                            hardwareConfigManager.getActiveConfig().getName())
+                    );
+                }
+            });
+
             updateStatusView();
         }
 
@@ -627,6 +661,18 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                     ReceiveGamepadState castMsg = (ReceiveGamepadState) msg;
                     updateGamepads(castMsg.getGamepad1(), castMsg.getGamepad2());
                     break;
+                }
+                case SET_HARDWARE_CONFIG: {
+                    String hardwareConfigName = ((SetHardwareConfig) msg).getHardwareConfigName();
+
+                    activeOpMode.with(o -> {
+                        // Don't allow changing the config unless stopped. Who knows what undefined behavior that would cause
+                       if(o.status != RobotStatus.OpModeStatus.STOPPED) return;
+
+                       hardwareConfigList.with(l -> {
+                           hardwareConfigManager.setActiveConfig(false, l.get(hardwareConfigName));
+                       });
+                    });
                 }
                 default: {
                     Log.w(TAG, "Received unknown message of type " + msg.getType());
@@ -879,6 +925,10 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
 
         Thread t = new Thread(new ListOpModesRunnable());
         t.start();
+
+        // This gets called every time the robot soft-restarts, which includes when modifying/switching configs
+        Thread hardwareConfigThread = new Thread(new ListHardwareConfigsRunnable());
+        hardwareConfigThread.start();
     }
 
     private void internalPopulateMenu(Menu menu) {

--- a/client/src/components/ConfigurableLayout/ConfigurableLayout.tsx
+++ b/client/src/components/ConfigurableLayout/ConfigurableLayout.tsx
@@ -23,6 +23,7 @@ import TelemetryView from '@/components/views/TelemetryView';
 import CameraView from '@/components/views/CameraView';
 import OpModeView from '@/components/views/OpModeView';
 import LoggingView from '@/components/views/LoggingView/LoggingView';
+import HardwareConfigView from '@/components/views/HardwareConfigView';
 
 import RadialFab from './RadialFab/RadialFab';
 import RadialFabChild from './RadialFab/RadialFabChild';
@@ -41,7 +42,6 @@ import CreateIconURL from '@/assets/icons/create.svg';
 
 import { colors } from '@/hooks/useTheme';
 import { useTheme } from '@/hooks/useTheme';
-import HardwareConfigView from '../views/HardwareConfigView';
 
 function maxArray(a: number[], b: number[]) {
   if (a.length !== b.length) {

--- a/client/src/components/ConfigurableLayout/ConfigurableLayout.tsx
+++ b/client/src/components/ConfigurableLayout/ConfigurableLayout.tsx
@@ -41,6 +41,7 @@ import CreateIconURL from '@/assets/icons/create.svg';
 
 import { colors } from '@/hooks/useTheme';
 import { useTheme } from '@/hooks/useTheme';
+import HardwareConfigView from '../views/HardwareConfigView';
 
 function maxArray(a: number[], b: number[]) {
   if (a.length !== b.length) {
@@ -68,6 +69,7 @@ const VIEW_MAP: { [key in ConfigurableView]: ReactElement } = {
   [ConfigurableView.CAMERA_VIEW]: <CameraView />,
   [ConfigurableView.OPMODE_VIEW]: <OpModeView />,
   [ConfigurableView.LOGGING_VIEW]: <LoggingView />,
+  [ConfigurableView.HARDWARE_CONFIG_VIEW]: <HardwareConfigView />,
 };
 
 const LOCAL_STORAGE_LAYOUT_KEY = 'configurableLayoutStorage';

--- a/client/src/components/ConfigurableLayout/ViewPicker.tsx
+++ b/client/src/components/ConfigurableLayout/ViewPicker.tsx
@@ -114,6 +114,13 @@ const listContent = [
     customStyles: 'focus:ring-purple-600',
     iconBg: 'bg-purple-500',
   },
+  {
+    title: 'Hardware Config View',
+    view: ConfigurableView.HARDWARE_CONFIG_VIEW,
+    icon: <SettingsIcon className="h-5 w-5" />,
+    customStyles: 'focus:ring-teal-600',
+    iconBg: 'bg-teal-500',
+  },
 ];
 
 const ViewPicker = (props: ViewPickerProps) => {

--- a/client/src/components/views/HardwareConfigView.tsx
+++ b/client/src/components/views/HardwareConfigView.tsx
@@ -1,0 +1,150 @@
+import { Component, ChangeEvent } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { RootState } from '@/store/reducers';
+import OpModeStatus from '@/enums/OpModeStatus';
+import BaseView, {
+  BaseViewHeading,
+  BaseViewBody,
+  BaseViewProps,
+  BaseViewHeadingProps,
+} from './BaseView';
+
+import { setHardwareConfig } from '@/store/actions/hardwareconfig';
+
+type HardwareConfigViewState = {
+  selectedHardwareConfig: string;
+};
+
+const mapStateToProps = ({ status, hardwareConfig }: RootState) => ({
+  ...status,
+  ...hardwareConfig,
+});
+
+const mapDispatchToProps = {
+  setHardwareConfig: (hardwareConfig: string) => setHardwareConfig(hardwareConfig),
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+type HardwareConfigViewProps = ConnectedProps<typeof connector> &
+  BaseViewProps &
+  BaseViewHeadingProps;
+
+const ActionButton = ({
+  children,
+  className,
+  ...props
+}: JSX.IntrinsicElements['button']) => (
+  <button
+    className={`ml-2 rounded-md border py-1 px-3 shadow-md ${className}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConfigViewState> {
+  constructor(props: HardwareConfigViewProps) {
+    super(props);
+
+    this.state = {
+      selectedHardwareConfig: '',
+    };
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(evt: ChangeEvent<HTMLSelectElement>) {
+    this.setState({
+      selectedHardwareConfig: evt.target.value,
+    });
+  }
+
+  renderSetButton() {
+    return (
+      <ActionButton
+        className={`
+          border-blue-300 bg-blue-200 transition-colors
+          dark:border-transparent dark:bg-blue-600 dark:text-blue-50 dark:highlight-white/30
+          dark:hover:border-blue-400/80 dark:focus:bg-blue-700
+        `}
+        onClick={() => this.props.setHardwareConfig(this.state.selectedHardwareConfig)}
+      >
+        Set
+      </ActionButton>
+    );
+  }
+
+  renderButtons() {
+    const { activeOpModeStatus, hardwareConfigList } = this.props;
+
+    if (hardwareConfigList.length === 0) {
+      return null;
+    } else if (activeOpModeStatus === OpModeStatus.STOPPED) {
+      return this.renderSetButton();
+    }
+  }
+
+  render() {
+    const {
+      available,
+      activeOpModeStatus,
+      hardwareConfigList,
+      currentHardwareConfig,
+    } = this.props;
+
+    if (!available) {
+      return (
+        <BaseView isUnlocked={this.props.isUnlocked}>
+          <BaseViewHeading isDraggable={this.props.isDraggable}>
+          Hardware Config
+          </BaseViewHeading>
+          <BaseViewBody className="flex-center">
+            <h3 className="text-md text-center">
+            Hardware Config controls have not initialized
+            </h3>
+          </BaseViewBody>
+        </BaseView>
+      );
+    }
+
+    return (
+      <BaseView isUnlocked={this.props.isUnlocked}>
+        <div className="flex">
+          <BaseViewHeading isDraggable={this.props.isDraggable}>
+            Hardware Config
+          </BaseViewHeading>
+        </div>
+        <BaseViewBody>
+          <select
+            className={`
+              m-1 mr-2 rounded border border-gray-300 bg-gray-200 p-1 pr-6 
+              shadow-md transition focus:border-primary-500
+              focus:ring-primary-500 disabled:text-gray-600 disabled:shadow-none
+              dark:border-slate-500/80 dark:bg-slate-700 dark:text-slate-200
+            `}
+            //value={this.state.selectedHardwareConfig}
+            disabled={
+              activeOpModeStatus !== OpModeStatus.STOPPED
+            }
+            onChange={this.onChange}
+            // This element is uncontrolled to be able to set a default option. I'm not sure if there's a better option here
+            defaultValue={currentHardwareConfig}
+          >
+            {hardwareConfigList.length === 0 ? (
+              <option>Loading...</option>
+            ) : (
+              hardwareConfigList
+                .sort()
+                .map((opMode: string) => <option key={opMode}>{opMode}</option>)
+            )}
+          </select>
+          {this.renderButtons()}
+        </BaseViewBody>
+      </BaseView>
+    );
+  }
+}
+
+export default connector(HardwareConfigView);

--- a/client/src/components/views/HardwareConfigView.tsx
+++ b/client/src/components/views/HardwareConfigView.tsx
@@ -11,6 +11,7 @@ import BaseView, {
 } from './BaseView';
 
 import { setHardwareConfig } from '@/store/actions/hardwareconfig';
+import { STOP_OP_MODE_TAG } from '@/store/types';
 
 type HardwareConfigViewState = {
   selectedHardwareConfig: string;
@@ -77,11 +78,11 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
   }
 
   renderButtons() {
-    const { activeOpModeStatus, hardwareConfigList } = this.props;
+    const { activeOpModeStatus, hardwareConfigList, activeOpMode } = this.props;
 
     if (hardwareConfigList.length === 0) {
       return null;
-    } else if (activeOpModeStatus === OpModeStatus.STOPPED) {
+    } else if (activeOpModeStatus === OpModeStatus.STOPPED || activeOpMode === STOP_OP_MODE_TAG) {
       return this.renderSetButton();
     }
   }
@@ -92,6 +93,7 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
       activeOpModeStatus,
       hardwareConfigList,
       currentHardwareConfig,
+      activeOpMode,
     } = this.props;
 
     if (!available) {
@@ -126,7 +128,7 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
             `}
             //value={this.state.selectedHardwareConfig}
             disabled={
-              activeOpModeStatus !== OpModeStatus.STOPPED
+              activeOpModeStatus !== OpModeStatus.STOPPED && activeOpMode !== STOP_OP_MODE_TAG
             }
             onChange={this.onChange}
             // This element is uncontrolled to be able to set a default option. I'm not sure if there's a better option here

--- a/client/src/components/views/HardwareConfigView.tsx
+++ b/client/src/components/views/HardwareConfigView.tsx
@@ -124,6 +124,21 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
           </BaseViewHeading>
         </div>
         <BaseViewBody>
+          <span
+            style={
+              this.state.selectedHardwareConfig === this.props.currentHardwareConfig
+                ? {
+                    userSelect: 'none',
+                    opacity: 0.0,
+                  }
+                : {
+                    userSelect: 'auto',
+                    opacity: 1.0,
+                  } 
+            }
+          >
+            *
+          </span>
           <select
             className={`
               m-1 mr-2 rounded border border-gray-300 bg-gray-200 p-1 pr-6 

--- a/client/src/components/views/HardwareConfigView.tsx
+++ b/client/src/components/views/HardwareConfigView.tsx
@@ -62,6 +62,12 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
     });
   }
 
+  componentDidUpdate(prevProps: Readonly<HardwareConfigViewProps>) {
+    if(prevProps.currentHardwareConfig !== this.props.currentHardwareConfig) {
+      this.setState({ selectedHardwareConfig: this.props.currentHardwareConfig });
+    }
+  }
+
   renderSetButton() {
     return (
       <ActionButton
@@ -92,7 +98,6 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
       available,
       activeOpModeStatus,
       hardwareConfigList,
-      currentHardwareConfig,
       activeOpMode,
     } = this.props;
 
@@ -126,13 +131,11 @@ class HardwareConfigView extends Component<HardwareConfigViewProps, HardwareConf
               focus:ring-primary-500 disabled:text-gray-600 disabled:shadow-none
               dark:border-slate-500/80 dark:bg-slate-700 dark:text-slate-200
             `}
-            //value={this.state.selectedHardwareConfig}
+            value={this.state.selectedHardwareConfig}
             disabled={
               activeOpModeStatus !== OpModeStatus.STOPPED && activeOpMode !== STOP_OP_MODE_TAG
             }
             onChange={this.onChange}
-            // This element is uncontrolled to be able to set a default option. I'm not sure if there's a better option here
-            defaultValue={currentHardwareConfig}
           >
             {hardwareConfigList.length === 0 ? (
               <option>Loading...</option>

--- a/client/src/enums/ConfigurableView.ts
+++ b/client/src/enums/ConfigurableView.ts
@@ -6,4 +6,5 @@ export enum ConfigurableView {
   CAMERA_VIEW,
   OPMODE_VIEW,
   LOGGING_VIEW,
+  HARDWARE_CONFIG_VIEW,
 }

--- a/client/src/store/actions/hardwareconfig.ts
+++ b/client/src/store/actions/hardwareconfig.ts
@@ -1,0 +1,16 @@
+import { RECEIVE_HARDWARE_CONFIG_LIST, SET_HARDWARE_CONFIG, SetHardwareConfigAction, ReceiveHardwareConfigListAction } from "../types/hardwareconfig";
+
+export const setHardwareConfig = (hardwareConfigName: string): SetHardwareConfigAction => ({
+    type: SET_HARDWARE_CONFIG,
+    hardwareConfigName,
+});
+
+export const receiveHardwareConfigList = (
+    hardwareConfigList: string[],
+    currentHardwareConfig: string,
+): ReceiveHardwareConfigListAction => ({
+    type: RECEIVE_HARDWARE_CONFIG_LIST,
+    hardwareConfigList,
+    currentHardwareConfig,
+}
+)

--- a/client/src/store/actions/socket.ts
+++ b/client/src/store/actions/socket.ts
@@ -6,8 +6,10 @@ import {
   ReceivePingTimeAction,
   RECEIVE_CONNECTION_STATUS,
   RECEIVE_PING_TIME,
+  ReceiveHardwareConfigListAction,
 } from '@/store/types';
 import { receiveOpModeList } from './status';
+import { receiveHardwareConfigList } from './hardwareconfig';
 
 export const receivePingTime = (pingTime: number): ReceivePingTimeAction => ({
   type: RECEIVE_PING_TIME,
@@ -17,7 +19,7 @@ export const receivePingTime = (pingTime: number): ReceivePingTimeAction => ({
 export const receiveConnectionStatus =
   (isConnected: boolean) =>
   (
-    dispatch: Dispatch<ReceiveConnectionStatusAction | ReceiveOpModeListAction>,
+    dispatch: Dispatch<ReceiveConnectionStatusAction | ReceiveOpModeListAction | ReceiveHardwareConfigListAction>,
   ) => {
     dispatch({
       type: RECEIVE_CONNECTION_STATUS,
@@ -26,5 +28,6 @@ export const receiveConnectionStatus =
 
     if (!isConnected) {
       dispatch(receiveOpModeList([]));
+      dispatch(receiveHardwareConfigList([], ''));
     }
   };

--- a/client/src/store/middleware/socketMiddleware.ts
+++ b/client/src/store/middleware/socketMiddleware.ts
@@ -10,6 +10,7 @@ import {
   INIT_OP_MODE,
   RECEIVE_GAMEPAD_STATE,
   RECEIVE_ROBOT_STATUS,
+  SET_HARDWARE_CONFIG,
   START_OP_MODE,
   STOP_OP_MODE,
 } from '@/store/types';
@@ -65,6 +66,7 @@ const socketMiddleware: Middleware<Record<string, unknown>, RootState> =
       case 'GET_CONFIG':
       case INIT_OP_MODE:
       case START_OP_MODE:
+      case SET_HARDWARE_CONFIG:
       case STOP_OP_MODE: {
         if (socket !== undefined && socket.readyState === WebSocket.OPEN) {
           socket.send(JSON.stringify(action));

--- a/client/src/store/reducers/hardwareconfig.ts
+++ b/client/src/store/reducers/hardwareconfig.ts
@@ -1,0 +1,28 @@
+import { RECEIVE_HARDWARE_CONFIG_LIST, ReceiveHardwareConfigListAction } from "@/store/types"
+import { HardwareConfigState } from "../types/hardwareconfig";
+
+const initialState: HardwareConfigState = {
+    hardwareConfigList: [],
+    currentHardwareConfig: '',
+}
+
+const hardwareConfigReducer = (
+    state = initialState,
+    action: 
+      | ReceiveHardwareConfigListAction,
+) => {
+    switch (action.type) {
+        case RECEIVE_HARDWARE_CONFIG_LIST: {
+            return {
+                ...state,
+                hardwareConfigList: action.hardwareConfigList,
+                currentHardwareConfig: action.currentHardwareConfig,
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+}
+
+export default hardwareConfigReducer;

--- a/client/src/store/reducers/index.ts
+++ b/client/src/store/reducers/index.ts
@@ -8,6 +8,7 @@ import statusReducer from './status';
 import cameraReducer from './camera';
 import settingsReducer from './settings';
 import gamepadReducer from './gamepad';
+import hardwareConfigReducer from './hardwareconfig';
 import { createDispatchHook } from 'react-redux';
 
 const rootReducer = combineReducers({
@@ -18,6 +19,7 @@ const rootReducer = combineReducers({
   camera: cameraReducer,
   settings: settingsReducer,
   gamepad: gamepadReducer,
+  hardwareConfig: hardwareConfigReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/store/types/hardwareconfig.ts
+++ b/client/src/store/types/hardwareconfig.ts
@@ -1,0 +1,18 @@
+export const SET_HARDWARE_CONFIG = 'SET_HARDWARE_CONFIG';
+export const RECEIVE_HARDWARE_CONFIG_LIST = 'RECEIVE_HARDWARE_CONFIG_LIST';
+
+export type HardwareConfigState = {
+  hardwareConfigList: string[];
+  currentHardwareConfig: string;
+};
+
+export type SetHardwareConfigAction = {
+    type: typeof SET_HARDWARE_CONFIG;
+    hardwareConfigName: string;
+}
+
+export type ReceiveHardwareConfigListAction = {
+    type: typeof RECEIVE_HARDWARE_CONFIG_LIST;
+    hardwareConfigList: string[];
+    currentHardwareConfig: string;
+}

--- a/client/src/store/types/index.ts
+++ b/client/src/store/types/index.ts
@@ -80,3 +80,12 @@ export type {
   TelemetryItem,
   ReceiveTelemetryAction,
 } from './telemetry';
+
+export { 
+  SET_HARDWARE_CONFIG, 
+  RECEIVE_HARDWARE_CONFIG_LIST, 
+} from './hardwareconfig';
+export type {
+  SetHardwareConfigAction,
+  ReceiveHardwareConfigListAction,
+} from './hardwareconfig';


### PR DESCRIPTION
This PR adds the ability for user to change what predefined hardware configuration is active through the Dashboard. Configurations must still be defined through the Driver Station.

Because it does not allow arbitrary edits to be made to the configuration, it does not resolve #106, although I would love for that to be implemented and I hope to work on that in the near(ish) future as an expansion of this system.

I plan to test this on actual hardware tomorrow; until then it is marked as a draft as there are certain concerns I want to test through first (primarily the config list getting out date). In the meantime, I would love feedback as I'm sure there are some problems/best-practices I missed :D.

![image](https://github.com/user-attachments/assets/ca78a543-262c-4fcc-aac6-c7dd7dd05872)
