### PR TITLE
Fix docs having a bad path for dashboard screenshot

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,9 @@ layout: default
 * Camera streaming
 * Limited op mode controls and gamepad support
 
-![Dashboard screenshot](images/dashboard.png)
+|     Screenshot of custom layout     |        Screenshot with theme        |
+| :---------------------------------: | :---------------------------------: |
+| ![](images/readme-screenshot-2.jpg) | ![](images/readme-screenshot-1.jpg) |
 
 # Documentation
 


### PR DESCRIPTION
Previously, the docs tried to access a screenshot which doesn't exist, so no screenshot was shown in the docs.
I just copy pasted the markdown for screenshots from the README to fix this
