### PR TITLE
Fix missing icon

### DIFF
--- a/client/src/assets/icons/delete.svg
+++ b/client/src/assets/icons/delete.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="white" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>


### PR DESCRIPTION
#162 had a dependency on the Delete.svg icon that was removed in 08660ad965bfe4cd2df96e0e8e70dc7f7bb7f32e. Because it was removed, master does not currently work. This PR restores the icon.