### PR TITLE
Fix Kotlin companion objects not showing fields as configurable

### DIFF
--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -560,19 +560,30 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                 try {
                     Class<?> configClass = Class.forName(className, false, classLoader);
 
-                    if (!configClass.isAnnotationPresent(Config.class)
-                        || configClass.isAnnotationPresent(Disabled.class)) {
+                    if (!configClass.isAnnotationPresent(Config.class)) {
                         continue;
                     }
 
                     String name = configClass.getSimpleName();
                     String altName = configClass.getAnnotation(Config.class).value();
+
+                    // Special case for Kotlin companion objects
+                    if (configClass.getSimpleName().equals("Companion")) {
+                        configClass = configClass.getEnclosingClass();
+
+                        name = configClass.getSimpleName();
+                    }
+
+                    if (configClass.isAnnotationPresent(Disabled.class)) {
+                        continue;
+                    }
+
                     if (!altName.isEmpty()) {
                         name = altName;
                     }
 
                     customVariable.putVariable(name,
-                        ReflectionConfig.createVariableFromClass(configClass));
+                            ReflectionConfig.createVariableFromClass(configClass));
                 } catch (ClassNotFoundException | NoClassDefFoundError ignored) {
                     // dash is unable to access many classes and reporting every instance
                     // only clutters the logs

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -568,7 +568,7 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                     String altName = configClass.getAnnotation(Config.class).value();
 
                     // Special case for Kotlin companion objects
-                    if (configClass.getSimpleName().equals("Companion")) {
+                    if (configClass.getSimpleName().equals("Companion") && configClass.getEnclosingClass() != null) {
                         configClass = configClass.getEnclosingClass();
 
                         name = configClass.getSimpleName();


### PR DESCRIPTION
Companion object fields are somewhat-misleadingly placed onto the parent class when compiled with `@JvmField`, which makes `@Config` fail to find any fields when applied to the companion. This PR adds an extra check to instead process the parent class when applied to the companion.

Before:
![Screenshot_20250619-090433](https://github.com/user-attachments/assets/b794460e-298a-434b-8f7a-627307592614)

After:
![Screenshot_20250619-090224](https://github.com/user-attachments/assets/bab93aa3-3ce1-4105-ae58-6627d82c7e6d)
