### PR TITLE
Support the standard gamepad mapping

### DIFF
--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -1408,35 +1408,40 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
     }
 
     public static void copyIntoSdkGamepad(ReceiveGamepadState.Gamepad src, Gamepad dst) {
-        dst.left_stick_x = src.left_stick_x;
-        dst.left_stick_y = src.left_stick_y;
-        dst.right_stick_x = src.right_stick_x;
-        dst.right_stick_y = src.right_stick_y;
+        // We need to copy from an intermediate so the SDK can handle the rising/falling edge detection
+        // Also, doing it like this means the SDK handles equivalencies between
+        // standard and Playstation buttons (i.e. converting A -> Cross and vice versa)
+        Gamepad intermediate = new Gamepad();
+        intermediate.left_stick_x = src.left_stick_x;
+        intermediate.left_stick_y = src.left_stick_y;
+        intermediate.right_stick_x = src.right_stick_x;
+        intermediate.right_stick_y = src.right_stick_y;
 
-        dst.dpad_up = src.dpad_up;
-        dst.dpad_down = src.dpad_down;
-        dst.dpad_left = src.dpad_left;
-        dst.dpad_right = src.dpad_right;
+        intermediate.dpad_up = src.dpad_up;
+        intermediate.dpad_down = src.dpad_down;
+        intermediate.dpad_left = src.dpad_left;
+        intermediate.dpad_right = src.dpad_right;
 
-        dst.a = src.a;
-        dst.b = src.b;
-        dst.x = src.x;
-        dst.y = src.y;
+        intermediate.a = src.a;
+        intermediate.b = src.b;
+        intermediate.x = src.x;
+        intermediate.y = src.y;
 
-        dst.guide = src.guide;
-        dst.start = src.start;
-        dst.back = src.back;
+        intermediate.guide = src.guide;
+        intermediate.start = src.start;
+        intermediate.back = src.back;
 
-        dst.left_bumper = src.left_bumper;
-        dst.right_bumper = src.right_bumper;
+        intermediate.left_bumper = src.left_bumper;
+        intermediate.right_bumper = src.right_bumper;
 
-        dst.left_stick_button = src.left_stick_button;
-        dst.right_stick_button = src.right_stick_button;
+        intermediate.left_stick_button = src.left_stick_button;
+        intermediate.right_stick_button = src.right_stick_button;
 
-        dst.left_trigger = src.left_trigger;
-        dst.right_trigger = src.right_trigger;
+        intermediate.left_trigger = src.left_trigger;
+        intermediate.right_trigger = src.right_trigger;
 
-        dst.touchpad = src.touchpad;
+        intermediate.touchpad = src.touchpad;
+        dst.copy(intermediate);
     }
 
     private void updateGamepads(ReceiveGamepadState.Gamepad gamepad1,

--- a/client/src/enums/GamepadType.ts
+++ b/client/src/enums/GamepadType.ts
@@ -18,7 +18,7 @@ import { Values } from '@/typeHelpers';
 
 const GamepadType = {
   LOGITECH_DUAL_ACTION: 'LOGITECH_DUAL_ACTION',
-  XBOX_360: 'XBOX_360',
+  STANDARD: 'STANDARD', // Standard as defined by W3C Gamepad spec (https://www.w3.org/TR/gamepad/#remapping)
   SONY_DUALSHOCK_4: 'SONY_DUALSHOCK_4',
   UNKNOWN: 'UNKNOWN',
 } as const;
@@ -38,8 +38,6 @@ export default {
   getFromGamepad: (gamepad: Gamepad) => {
     if (gamepad.id.search('Logitech Dual Action') !== -1) {
       return GamepadType.LOGITECH_DUAL_ACTION;
-    } else if (gamepad.id.search('Xbox 360') !== -1) {
-      return GamepadType.XBOX_360;
     } else if (
       gamepad.id.search(SONY_VID) !== -1 &&
       gamepad.id.search(
@@ -53,6 +51,10 @@ export default {
       ) !== -1
     ) {
       return GamepadType.SONY_DUALSHOCK_4;
+    } else if (gamepad.mapping.search('standard') !== -1 
+      || gamepad.id.search('Xbox 360') !== -1
+      || gamepad.id.toLowerCase().search('xinput') !== -1) {
+      return GamepadType.STANDARD;
     } else {
       return GamepadType.UNKNOWN;
     }
@@ -62,7 +64,7 @@ export default {
     switch (gamepadType) {
       case GamepadType.LOGITECH_DUAL_ACTION:
         return 0.06;
-      case GamepadType.XBOX_360:
+      case GamepadType.STANDARD:
         return 0.15;
       case GamepadType.SONY_DUALSHOCK_4:
         return 0.04;

--- a/client/src/store/middleware/gamepadMiddleware.ts
+++ b/client/src/store/middleware/gamepadMiddleware.ts
@@ -110,16 +110,18 @@ const extractGamepadState = (gamepad: Gamepad) => {
         left_trigger: gamepad.buttons[6].value,
         right_trigger: gamepad.buttons[7].value,
       };
-    case GamepadType.XBOX_360:
+    case GamepadType.STANDARD:
       return {
         // same as SONY_DUALSHOCK_4 except guide and touchpad buttons
-        // tested with generic controller id='Xbox 360 Controller (XInput STANDARD GAMEPAD)' and mapping='standard'
-        // on Win10/Chrome v88 and Edge v87
-        // USB ID=24C6, PID=530A
+        // tested with generic controller reported by Chromium-based as
+        // id='Xbox 360 Controller (XInput STANDARD GAMEPAD)' and mapping='standard'
+        // on Firefox reports as id='xinput' and mapping='standard'
+        // tested on Win11/Chrome v138, Edge v139, Firefox v135
+        // USB ID=24C6, PID=543A
         left_stick_x: cleanMotionValues(gamepad.axes[0]),
         left_stick_y: cleanMotionValues(gamepad.axes[1]),
-        right_stick_x: cleanMotionValues(gamepad.axes[3]),
-        right_stick_y: cleanMotionValues(gamepad.axes[4]),
+        right_stick_x: cleanMotionValues(gamepad.axes[2]),
+        right_stick_y: cleanMotionValues(gamepad.axes[3]),
 
         dpad_up: gamepad.buttons[12].pressed,
         dpad_down: gamepad.buttons[13].pressed,


### PR DESCRIPTION
This PR improves compatibility for gamepads across browsers by making use of the 'standard' [W3C Gamepad mapping](https://www.w3.org/TR/gamepad/#remapping). All browsers which implement the spec are 'recommended' to convert non-standard orderings to the standard mapping, which means making use of this mapping is the only way to guarantee compatibility long-term as browsers perform these conversions for existing controllers over time. Any controller-specific change we make (excluding the handling of additional buttons) would eventually become obsolete as the controller is handled by the browser itself. 

The existing `XBOX_360` case varies only in a way I believe to be a bug (see below) from the Standard mapping, so I have opted to rename it to `STANDARD` and use it for this case. The existing checks for the category have been kept, so there is no loss in detected compatibility. These controllers are typically reported as simply 'xinput' on Firefox rather than the full name given in Chromium, which means that the same controller could be considered supported on one browser while being seen as not supported on another despite working on both. I've added an additional check to rectify this, but I believe that both of these checks can be removed entirely, or at least simplified to only the 'xinput' search.

This PR also fixes the issue outlined in #91. The reference gamepad shown in that PR, the gamepad used for originally testing the `XBOX_360` case (as outlined in the code), and both of the gamepads I am using for testing (and have successfully reproduced the issue on) all report a standard mapping, which I believe shows that non-conformance to the W3C spec is a bug. Additionally, the comment describes the case as the same as the `SONY_DUALSHOCK_4` case, but the `XBOX_360` case varies in this way. And #47, the original PR adding proper Xbox controller support, makes clear that the intended mapping was entirely standard.

One point I wasn't sure about is the reason that `guide` is not correctly mapped to the buttons array. Given this button is both a part of the spec and used within `SONY_DUALSHOCK_4`, I believe it should be possible to begin handling the button normally. (See also #48, which briefly mentions this issue.) If this change can be made, the `SONY_DUALSHOCK_4` and `STANDARD` cases will be practically identical except for the non-standard touchpad button, and I believe it would be possible (and debateably, desireable) to merge the cases into a single block. Let me know your thoughts on this.

Given the mapping used in #174 is identical to the one used here, I believe this PR will effectively provide support for the controller and *should* be capable of closing it.

I've tested this on Windows 11 with Chrome v138, Edge v139, and Firefox v135 with both an Xbox 360 controller and a generic XInput controller with Xbox buttons. I'm marking this as a draft for now to allow for feedback; next week I will test on Linux with Chromium/Firefox with both of those controllers and an additional Playstation 4 controller. I don't expect any issues.

One other side-note: It may be a good idea to re-test the Logitech Dual Action controller to see if browsers now support automatically remapping it to a standard mapping. If so, as noted above the current implementation is likely no longer functional.

Closes #48.

![The standard button mapping](https://www.w3.org/TR/gamepad/standard_gamepad.svg)