### PR TITLE
Add OpMode grouping and info to dashboard

### DIFF
--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/OpModeInfo.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/OpModeInfo.java
@@ -1,0 +1,19 @@
+package com.acmerobotics.dashboard;
+
+public class OpModeInfo {
+    private String name;
+    private String group;
+
+    public OpModeInfo(String name, String group) {
+        this.name = name;
+        this.group = group;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+}

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/ReceiveOpModeList.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/ReceiveOpModeList.java
@@ -2,14 +2,25 @@ package com.acmerobotics.dashboard.message.redux;
 
 import com.acmerobotics.dashboard.message.Message;
 import com.acmerobotics.dashboard.message.MessageType;
+import com.acmerobotics.dashboard.OpModeInfo;
 import java.util.List;
 
 public class ReceiveOpModeList extends Message {
     private List<String> opModeList;
+    private List<OpModeInfo> opModeInfoList;
 
-    public ReceiveOpModeList(List<String> opModeList) {
+    public ReceiveOpModeList(List<String> opModeList, List<OpModeInfo> opModeInfoList) {
         super(MessageType.RECEIVE_OP_MODE_LIST);
 
         this.opModeList = opModeList;
+        this.opModeInfoList = opModeInfoList;
+    }
+
+    public List<String> getOpModeList() {
+        return opModeList;
+    }
+
+    public List<OpModeInfo> getOpModeInfoList() {
+        return opModeInfoList;
     }
 }

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/ReceiveOpModeList.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/ReceiveOpModeList.java
@@ -6,21 +6,11 @@ import com.acmerobotics.dashboard.OpModeInfo;
 import java.util.List;
 
 public class ReceiveOpModeList extends Message {
-    private List<String> opModeList;
     private List<OpModeInfo> opModeInfoList;
 
-    public ReceiveOpModeList(List<String> opModeList, List<OpModeInfo> opModeInfoList) {
+    public ReceiveOpModeList(List<OpModeInfo> opModeInfoList) {
         super(MessageType.RECEIVE_OP_MODE_LIST);
 
-        this.opModeList = opModeList;
         this.opModeInfoList = opModeInfoList;
-    }
-
-    public List<String> getOpModeList() {
-        return opModeList;
-    }
-
-    public List<OpModeInfo> getOpModeInfoList() {
-        return opModeInfoList;
     }
 }

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -9,7 +9,6 @@ import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
 import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.OpModeInfo;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
-import com.acmerobotics.dashboard.testopmode.TestOpMode;
 import com.acmerobotics.dashboard.testopmode.TestOpModeManager;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoWSD;
@@ -64,17 +63,12 @@ public class TestDashboardInstance {
 
             opModeManager.setSendFun(this);
             
-            List<String> opModeNames = opModeManager
-                .getTestOpModes()
-                .stream().map(TestOpMode::getName)
-                .collect(Collectors.toList());
-            
             List<OpModeInfo> opModeInfoList = opModeManager
                 .getTestOpModes()
                 .stream().map(testOpMode -> new OpModeInfo(testOpMode.getName(), "Test"))
                 .collect(Collectors.toList());
             
-            send(new ReceiveOpModeList(opModeNames, opModeInfoList));
+            send(new ReceiveOpModeList(opModeInfoList));
             send(new ReceiveHardwareConfigList(
                 hardwareConfigManager.getTestHardwareConfigs(),
                 hardwareConfigManager.getActiveHardwareConfig()

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -7,12 +7,14 @@ import com.acmerobotics.dashboard.message.redux.ReceiveHardwareConfigList;
 import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
 import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
+import com.acmerobotics.dashboard.OpModeInfo;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
 import com.acmerobotics.dashboard.testopmode.TestOpMode;
 import com.acmerobotics.dashboard.testopmode.TestOpModeManager;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoWSD;
 import java.io.IOException;
+import java.util.List;
 import java.util.stream.Collectors;
 
 enum TestEnum {
@@ -61,12 +63,18 @@ public class TestDashboardInstance {
             sh.onOpen();
 
             opModeManager.setSendFun(this);
-            send(new ReceiveOpModeList(
-                opModeManager
-                    .getTestOpModes()
-                    .stream().map(TestOpMode::getName)
-                    .collect(Collectors.toList())
-            ));
+            
+            List<String> opModeNames = opModeManager
+                .getTestOpModes()
+                .stream().map(TestOpMode::getName)
+                .collect(Collectors.toList());
+            
+            List<OpModeInfo> opModeInfoList = opModeManager
+                .getTestOpModes()
+                .stream().map(testOpMode -> new OpModeInfo(testOpMode.getName(), "Test"))
+                .collect(Collectors.toList());
+            
+            send(new ReceiveOpModeList(opModeNames, opModeInfoList));
             send(new ReceiveHardwareConfigList(
                 hardwareConfigManager.getTestHardwareConfigs(),
                 hardwareConfigManager.getActiveHardwareConfig()

--- a/client/src/components/views/GraphView/GraphView.tsx
+++ b/client/src/components/views/GraphView/GraphView.tsx
@@ -139,7 +139,7 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
 
   noOpmodeRunning(props: GraphViewProps) {
     return (
-      props.status.opModeList?.length === 0 ||
+      props.status.opModeInfoList?.length === 0 ||
       props.status.activeOpMode === STOP_OP_MODE_TAG ||
       props.status.activeOpModeStatus === OpModeStatus.STOPPED
     );

--- a/client/src/components/views/LoggingView/LoggingView.tsx
+++ b/client/src/components/views/LoggingView/LoggingView.tsx
@@ -144,7 +144,7 @@ const LoggingView = ({
   isDraggable = false,
   isUnlocked = false,
 }: LoggingViewProps) => {
-  const { activeOpMode, activeOpModeStatus, opModeList } = useSelector(
+  const { activeOpMode, activeOpModeStatus, opModeInfoList } = useSelector(
     (state: RootState) => state.status,
   );
 
@@ -183,7 +183,7 @@ const LoggingView = ({
   );
 
   useEffect(() => {
-    if (opModeList?.length === 0) {
+    if (opModeInfoList?.length === 0) {
       setIsRecording(false);
     } else if (activeOpMode === STOP_OP_MODE_TAG) {
       setIsRecording(false);
@@ -196,7 +196,7 @@ const LoggingView = ({
     } else if (activeOpModeStatus === OpModeStatus.STOPPED) {
       setIsRecording(false);
     }
-  }, [activeOpMode, activeOpModeStatus, isRecording, opModeList, telemetry]);
+  }, [activeOpMode, activeOpModeStatus, isRecording, opModeInfoList, telemetry]);
 
   useEffect(() => {
     if (

--- a/client/src/components/views/OpModeView.tsx
+++ b/client/src/components/views/OpModeView.tsx
@@ -195,52 +195,43 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
     const ungroupedOpModes: string[] = [];
 
     opModeInfoList.forEach((opModeInfo) => {
-      if (
-        opModeInfo.group &&
-        opModeInfo.group !== '$$$$$$$' &&
-        opModeInfo.group.trim() !== ''
-      ) {
+      if (opModeInfo.group !== '') {
         // Has a valid group
         if (!groupedOpModes[opModeInfo.group]) {
           groupedOpModes[opModeInfo.group] = [];
         }
         groupedOpModes[opModeInfo.group].push(opModeInfo.name);
       } else {
-        // No group or default group - add to ungrouped
+        // No group - add to ungrouped
         ungroupedOpModes.push(opModeInfo.name);
       }
     });
 
-    const result = [];
-
     // Add grouped op modes first
     const sortedGroups = Object.keys(groupedOpModes).sort();
-    sortedGroups.forEach((group) => {
+    const groupedElements = sortedGroups.map((group) => {
       const sortedOpModes = groupedOpModes[group].sort();
-      result.push(
+      return (
         <optgroup key={group} label={group}>
           {sortedOpModes.map((opMode) => (
             <option key={opMode} value={opMode}>
               {opMode}
             </option>
           ))}
-        </optgroup>,
+        </optgroup>
       );
     });
 
     // Add ungrouped op modes at the bottom (sorted)
-    if (ungroupedOpModes.length > 0) {
-      const sortedUngrouped = ungroupedOpModes.sort();
-      result.push(
-        ...sortedUngrouped.map((opMode) => (
+    const ungroupedElements = ungroupedOpModes.length > 0
+      ? ungroupedOpModes.sort().map((opMode) => (
           <option key={opMode} value={opMode}>
             {opMode}
           </option>
-        )),
-      );
-    }
+        ))
+      : [];
 
-    return result;
+    return [...groupedElements, ...ungroupedElements];
   }
 
   render() {

--- a/client/src/components/views/OpModeView.tsx
+++ b/client/src/components/views/OpModeView.tsx
@@ -183,6 +183,66 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
     }
   }
 
+  renderOpModeOptions() {
+    const { opModeList, opModeInfoList } = this.props;
+
+    if (opModeList.length === 0) {
+      return <option>Loading...</option>;
+    }
+
+    // Separate grouped and ungrouped op modes
+    const groupedOpModes: Record<string, string[]> = {};
+    const ungroupedOpModes: string[] = [];
+
+    opModeInfoList.forEach((opModeInfo) => {
+      if (
+        opModeInfo.group &&
+        opModeInfo.group !== '$$$$$$$' &&
+        opModeInfo.group.trim() !== ''
+      ) {
+        // Has a valid group
+        if (!groupedOpModes[opModeInfo.group]) {
+          groupedOpModes[opModeInfo.group] = [];
+        }
+        groupedOpModes[opModeInfo.group].push(opModeInfo.name);
+      } else {
+        // No group or default group - add to ungrouped
+        ungroupedOpModes.push(opModeInfo.name);
+      }
+    });
+
+    const result = [];
+
+    // Add grouped op modes first
+    const sortedGroups = Object.keys(groupedOpModes).sort();
+    sortedGroups.forEach((group) => {
+      const sortedOpModes = groupedOpModes[group].sort();
+      result.push(
+        <optgroup key={group} label={group}>
+          {sortedOpModes.map((opMode) => (
+            <option key={opMode} value={opMode}>
+              {opMode}
+            </option>
+          ))}
+        </optgroup>,
+      );
+    });
+
+    // Add ungrouped op modes at the bottom (sorted)
+    if (ungroupedOpModes.length > 0) {
+      const sortedUngrouped = ungroupedOpModes.sort();
+      result.push(
+        ...sortedUngrouped.map((opMode) => (
+          <option key={opMode} value={opMode}>
+            {opMode}
+          </option>
+        )),
+      );
+    }
+
+    return result;
+  }
+
   render() {
     const {
       available,
@@ -273,13 +333,7 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
             }
             onChange={this.onChange}
           >
-            {opModeList.length === 0 ? (
-              <option>Loading...</option>
-            ) : (
-              opModeList
-                .sort()
-                .map((opMode: string) => <option key={opMode}>{opMode}</option>)
-            )}
+            {this.renderOpModeOptions()}
           </select>
           {this.renderButtons()}
           {errorMessage !== '' && (

--- a/client/src/components/views/OpModeView.tsx
+++ b/client/src/components/views/OpModeView.tsx
@@ -99,10 +99,10 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
       };
     } else if (
       state.selectedOpMode === '' ||
-      props.opModeList.indexOf(state.selectedOpMode) === -1
+      !props.opModeInfoList.some(info => info.name === state.selectedOpMode)
     ) {
       return {
-        selectedOpMode: props.opModeList[0] || '',
+        selectedOpMode: props.opModeInfoList[0]?.name || '',
       };
     } else {
       return {};
@@ -161,9 +161,9 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
   }
 
   renderButtons() {
-    const { activeOpMode, activeOpModeStatus, opModeList } = this.props;
+    const { activeOpMode, activeOpModeStatus, opModeInfoList } = this.props;
 
-    if (opModeList.length === 0) {
+    if (opModeInfoList.length === 0) {
       return null;
     } else if (activeOpMode === STOP_OP_MODE_TAG) {
       return this.renderInitButton();
@@ -184,9 +184,9 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
   }
 
   renderOpModeOptions() {
-    const { opModeList, opModeInfoList } = this.props;
+    const { opModeInfoList } = this.props;
 
-    if (opModeList.length === 0) {
+    if (opModeInfoList.length === 0) {
       return <option>Loading...</option>;
     }
 
@@ -247,7 +247,7 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
     const {
       available,
       activeOpMode,
-      opModeList,
+      opModeInfoList,
       warningMessage,
       errorMessage,
       gamepadsSupported,
@@ -329,7 +329,7 @@ class OpModeView extends Component<OpModeViewProps, OpModeViewState> {
             `}
             value={this.state.selectedOpMode}
             disabled={
-              activeOpMode !== STOP_OP_MODE_TAG || opModeList.length === 0
+              activeOpMode !== STOP_OP_MODE_TAG || opModeInfoList.length === 0
             }
             onChange={this.onChange}
           >

--- a/client/src/store/actions/status.ts
+++ b/client/src/store/actions/status.ts
@@ -4,7 +4,8 @@ import {
   ReceiveRobotStatusAction,
   RECEIVE_OP_MODE_LIST,
   RECEIVE_ROBOT_STATUS,
-} from '@/store/types';
+  OpModeInfo,
+} from '@/store/types/status';
 
 export const receiveRobotStatus = (
   status: StatusState,
@@ -14,8 +15,8 @@ export const receiveRobotStatus = (
 });
 
 export const receiveOpModeList = (
-  opModeList: string[],
+  opModeInfoList: OpModeInfo[],
 ): ReceiveOpModeListAction => ({
   type: RECEIVE_OP_MODE_LIST,
-  opModeList,
+  opModeInfoList,
 });

--- a/client/src/store/reducers/status.ts
+++ b/client/src/store/reducers/status.ts
@@ -17,6 +17,7 @@ const initialState: StatusState = {
   warningMessage: '',
   errorMessage: '',
   opModeList: [],
+  opModeInfoList: [],
   gamepadsSupported: true,
   batteryVoltage: -1.0,
 };
@@ -38,6 +39,7 @@ const statusReducer = (
       return {
         ...state,
         opModeList: action.opModeList,
+        opModeInfoList: action.opModeInfoList || [],
       };
     case GAMEPAD_SUPPORTED_STATUS:
       return {

--- a/client/src/store/reducers/status.ts
+++ b/client/src/store/reducers/status.ts
@@ -16,7 +16,6 @@ const initialState: StatusState = {
   activeOpModeStatus: OpModeStatus.STOPPED,
   warningMessage: '',
   errorMessage: '',
-  opModeList: [],
   opModeInfoList: [],
   gamepadsSupported: true,
   batteryVoltage: -1.0,
@@ -38,8 +37,7 @@ const statusReducer = (
     case RECEIVE_OP_MODE_LIST:
       return {
         ...state,
-        opModeList: action.opModeList,
-        opModeInfoList: action.opModeInfoList || [],
+        opModeInfoList: action.opModeInfoList,
       };
     case GAMEPAD_SUPPORTED_STATUS:
       return {

--- a/client/src/store/types/status.ts
+++ b/client/src/store/types/status.ts
@@ -29,7 +29,6 @@ export type StatusState = {
   warningMessage: string;
   errorMessage: string;
   batteryVoltage: number;
-  opModeList: string[];
   opModeInfoList: OpModeInfo[];
   gamepadsSupported: boolean;
 };
@@ -45,8 +44,7 @@ export type ReceiveRobotStatusAction = {
 
 export type ReceiveOpModeListAction = {
   type: typeof RECEIVE_OP_MODE_LIST;
-  opModeList: string[];
-  opModeInfoList?: OpModeInfo[];
+  opModeInfoList: OpModeInfo[];
 };
 
 export type GamepadSupportedStatus = {

--- a/client/src/store/types/status.ts
+++ b/client/src/store/types/status.ts
@@ -6,6 +6,11 @@ export const RECEIVE_ROBOT_STATUS = 'RECEIVE_ROBOT_STATUS';
 export const RECEIVE_OP_MODE_LIST = 'RECEIVE_OP_MODE_LIST';
 export const GAMEPAD_SUPPORTED_STATUS = 'GAMEPAD_SUPPORTED_STATUS';
 
+export type OpModeInfo = {
+  name: string;
+  group: string;
+};
+
 export type RobotStatus = {
   enabled: boolean;
   available: boolean;
@@ -25,6 +30,7 @@ export type StatusState = {
   errorMessage: string;
   batteryVoltage: number;
   opModeList: string[];
+  opModeInfoList: OpModeInfo[];
   gamepadsSupported: boolean;
 };
 
@@ -40,6 +46,7 @@ export type ReceiveRobotStatusAction = {
 export type ReceiveOpModeListAction = {
   type: typeof RECEIVE_OP_MODE_LIST;
   opModeList: string[];
+  opModeInfoList?: OpModeInfo[];
 };
 
 export type GamepadSupportedStatus = {


### PR DESCRIPTION
Introduces the OpModeInfo class and updates backend and frontend to support grouped OpModes. The OpMode list message now includes group information, and the client UI displays OpModes grouped by their group name, improving organization and usability.
<img width="550" height="510" alt="Screenshot 2025-08-23 at 12 18 48 AM" src="https://github.com/user-attachments/assets/2f1d9f02-f40e-4794-9d3b-91d15eb1404b" />
