### PR TITLE
Persist Graph Variable Selections Between Op Mode Runs

### DIFF
--- a/client/src/store/actions/graph.ts
+++ b/client/src/store/actions/graph.ts
@@ -1,0 +1,22 @@
+import {
+  GraphState,
+  SAVE_GRAPH_VARIABLES,
+  RECEIVE_GRAPH_VARIABLES,
+  GET_GRAPH_VARIABLES,
+} from '@/store/types/graph';
+
+export const saveGraphVariables = (selectedKeys: string[], windowMs: number) => ({
+  type: SAVE_GRAPH_VARIABLES,
+  selectedKeys,
+  windowMs,
+});
+
+export const receiveGraphVariables = (selectedKeys: string[], windowMs: number) => ({
+  type: RECEIVE_GRAPH_VARIABLES,
+  selectedKeys,
+  windowMs,
+});
+
+export const getGraphVariables = () => ({
+  type: GET_GRAPH_VARIABLES,
+});

--- a/client/src/store/middleware/storageMiddleware.ts
+++ b/client/src/store/middleware/storageMiddleware.ts
@@ -1,11 +1,14 @@
 import { Middleware } from 'redux';
 
 import LayoutPreset, { LayoutPresetType } from '@/enums/LayoutPreset';
-import { GET_LAYOUT_PRESET, SAVE_LAYOUT_PRESET } from '@/store/types';
+import { GET_LAYOUT_PRESET, SAVE_LAYOUT_PRESET, GET_GRAPH_VARIABLES, SAVE_GRAPH_VARIABLES } from '@/store/types';
 import { receiveLayoutPreset } from '@/store/actions/settings';
+import { receiveGraphVariables } from '@/store/actions/graph';
 import { RootState } from '@/store/reducers';
+import { DEFAULT_OPTIONS } from '@/components/views/GraphView/Graph';
 
 const LAYOUT_PRESET_KEY = 'layoutPreset';
+const GRAPH_VARIABLES_KEY = 'graphVariables';
 
 const storageMiddleware: Middleware<Record<string, unknown>, RootState> =
   (store) => (next) => (action) => {
@@ -22,6 +25,37 @@ const storageMiddleware: Middleware<Record<string, unknown>, RootState> =
         localStorage.setItem(LAYOUT_PRESET_KEY, action.preset);
 
         store.dispatch(receiveLayoutPreset(action.preset));
+
+        break;
+      }
+      case GET_GRAPH_VARIABLES: {
+        const storedData = localStorage.getItem(GRAPH_VARIABLES_KEY);
+        let selectedKeys: string[] = [];
+        let windowMs = DEFAULT_OPTIONS.windowMs;
+
+        if (storedData) {
+          try {
+            const parsed = JSON.parse(storedData);
+            selectedKeys = parsed.selectedKeys || [];
+            windowMs = parsed.windowMs || DEFAULT_OPTIONS.windowMs;
+          } catch (e) {
+            // If parsing fails, use defaults
+            console.warn('Failed to parse stored graph variables, using defaults');
+          }
+        }
+
+        store.dispatch(receiveGraphVariables(selectedKeys, windowMs));
+
+        break;
+      }
+      case SAVE_GRAPH_VARIABLES: {
+        const graphData = {
+          selectedKeys: action.selectedKeys,
+          windowMs: action.windowMs,
+        };
+        localStorage.setItem(GRAPH_VARIABLES_KEY, JSON.stringify(graphData));
+
+        store.dispatch(receiveGraphVariables(action.selectedKeys, action.windowMs));
 
         break;
       }

--- a/client/src/store/reducers/graph.ts
+++ b/client/src/store/reducers/graph.ts
@@ -1,0 +1,28 @@
+import {
+  GraphState,
+  GraphActions,
+  RECEIVE_GRAPH_VARIABLES,
+} from '@/store/types/graph';
+import { DEFAULT_OPTIONS } from '@/components/views/GraphView/Graph';
+
+const initialState: GraphState = {
+  selectedKeys: [],
+  windowMs: DEFAULT_OPTIONS.windowMs,
+};
+
+const graphReducer = (
+  state = initialState,
+  action: GraphActions,
+): GraphState => {
+  switch (action.type) {
+    case RECEIVE_GRAPH_VARIABLES:
+      return {
+        selectedKeys: action.selectedKeys,
+        windowMs: action.windowMs,
+      };
+    default:
+      return state;
+  }
+};
+
+export default graphReducer;

--- a/client/src/store/reducers/index.ts
+++ b/client/src/store/reducers/index.ts
@@ -10,6 +10,7 @@ import cameraReducer from './camera';
 import settingsReducer from './settings';
 import gamepadReducer from './gamepad';
 import hardwareConfigReducer from './hardwareconfig';
+import graphReducer from './graph';
 import { createDispatchHook } from 'react-redux';
 
 const rootReducer = combineReducers({
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   settings: settingsReducer,
   gamepad: gamepadReducer,
   hardwareConfig: hardwareConfigReducer,
+  graph: graphReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/store/types/graph.ts
+++ b/client/src/store/types/graph.ts
@@ -1,0 +1,26 @@
+export const SAVE_GRAPH_VARIABLES = 'SAVE_GRAPH_VARIABLES';
+export const RECEIVE_GRAPH_VARIABLES = 'RECEIVE_GRAPH_VARIABLES';
+export const GET_GRAPH_VARIABLES = 'GET_GRAPH_VARIABLES';
+
+export type GraphState = {
+  selectedKeys: string[];
+  windowMs: number;
+};
+
+export type SaveGraphVariablesAction = {
+  type: typeof SAVE_GRAPH_VARIABLES;
+  selectedKeys: string[];
+  windowMs: number;
+};
+
+export type ReceiveGraphVariablesAction = {
+  type: typeof RECEIVE_GRAPH_VARIABLES;
+  selectedKeys: string[];
+  windowMs: number;
+};
+
+export type GetGraphVariablesAction = {
+  type: typeof GET_GRAPH_VARIABLES;
+};
+
+export type GraphActions = SaveGraphVariablesAction | ReceiveGraphVariablesAction | GetGraphVariablesAction;

--- a/client/src/store/types/index.ts
+++ b/client/src/store/types/index.ts
@@ -92,3 +92,15 @@ export type {
 
 export { SET_REPLAY_OVERLAY } from './replay';
 export type { SetReplayOverlayAction } from './replay';
+
+export {
+  SAVE_GRAPH_VARIABLES,
+  RECEIVE_GRAPH_VARIABLES,
+  GET_GRAPH_VARIABLES,
+} from './graph';
+export type {
+  GraphState,
+  SaveGraphVariablesAction,
+  ReceiveGraphVariablesAction,
+  GetGraphVariablesAction,
+} from './graph';


### PR DESCRIPTION
This PR adds persistence for graph variable selections and window settings in the GraphView component. Previously, users had to re-select their telemetry variables every time they started a new op mode, which was tedious during iterative robot development.