### PR TITLE
Support guide button on standard mapping

### DIFF
--- a/client/src/store/middleware/gamepadMiddleware.ts
+++ b/client/src/store/middleware/gamepadMiddleware.ts
@@ -112,7 +112,7 @@ const extractGamepadState = (gamepad: Gamepad) => {
       };
     case GamepadType.STANDARD:
       return {
-        // same as SONY_DUALSHOCK_4 except guide and touchpad buttons
+        // same as SONY_DUALSHOCK_4 except touchpad button
         // tested with generic controller reported by Chromium-based as
         // id='Xbox 360 Controller (XInput STANDARD GAMEPAD)' and mapping='standard'
         // on Firefox reports as id='xinput' and mapping='standard'
@@ -133,7 +133,7 @@ const extractGamepadState = (gamepad: Gamepad) => {
         x: gamepad.buttons[2].pressed,
         y: gamepad.buttons[3].pressed,
 
-        guide: false,
+        guide: gamepad.buttons[16].pressed,
         start: gamepad.buttons[9].pressed,
         back: gamepad.buttons[8].pressed,
 


### PR DESCRIPTION
This probably won't work on all devices, the first thing that comes to mind is maybe not on Windows machines with Xbox Gamebar installed, but I don't think it can hurt in any case and it's useful on the devices it does work on. (See #186 - this button is a part of the W3C mapping.)