### PR TITLE
Display color sensors in hardware view

### DIFF
--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
@@ -487,7 +487,7 @@ public class HardwareOpMode extends OpMode {
             colorSensorVar.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.blue)));
         }
 
-        colorSensorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.getConnectionInfo())));
+        colorSensorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, extractI2CPort(colorSensor.getConnectionInfo())));
 
         return colorSensorVar;
     }
@@ -563,6 +563,18 @@ public class HardwareOpMode extends OpMode {
                 break;
             }
         }
-        return numericPart.equals("173") ? "Control Hub" : "Expansion Hub " + numericPart;
+        return numericPart.startsWith("173") ? "Control Hub" : "Expansion Hub " + numericPart;
+    }
+
+    private String extractI2CPort(String connectionInfo) {
+        String trimmedString = connectionInfo.substring(connectionInfo.indexOf("bus"));
+        String numericPart = "";
+        for (int i = 0; i < trimmedString.length(); i++) {
+            if (Character.isDigit(trimmedString.charAt(i))) {
+                numericPart = trimmedString.substring(i);
+                break;
+            }
+        }
+        return numericPart.substring(0, 1);
     }
 }

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
@@ -17,6 +17,7 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareDevice;
 import com.qualcomm.robotcore.hardware.NormalizedColorSensor;
+import com.qualcomm.robotcore.hardware.NormalizedRGBA;
 import com.qualcomm.robotcore.hardware.Servo;
 
 /**
@@ -480,9 +481,10 @@ public class HardwareOpMode extends OpMode {
         // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
         if (colorSensor instanceof NormalizedColorSensor) {
             NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
-            colorSensorVar.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().red)));
-            colorSensorVar.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().green)));
-            colorSensorVar.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().blue)));
+            NormalizedRGBA reading = normColorSensor.getNormalizedColors();
+            colorSensorVar.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.red)));
+            colorSensorVar.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.green)));
+            colorSensorVar.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.blue)));
         }
 
         colorSensorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.getConnectionInfo())));
@@ -512,9 +514,10 @@ public class HardwareOpMode extends OpMode {
             // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
             if (colorSensor instanceof NormalizedColorSensor) {
                 NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
-                stateUpdate.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().red)));
-                stateUpdate.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().green)));
-                stateUpdate.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().blue)));
+                NormalizedRGBA reading = normColorSensor.getNormalizedColors();
+                stateUpdate.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.red)));
+                stateUpdate.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.green)));
+                stateUpdate.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.blue)));
             }
 
             CustomVariable existingConfig = (CustomVariable) colorSensorsVar.getVariable(deviceName);

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
@@ -12,6 +12,7 @@ import com.acmerobotics.dashboard.config.variable.VariableType;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.CRServo;
+import com.qualcomm.robotcore.hardware.ColorSensor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareDevice;
@@ -113,6 +114,7 @@ public class HardwareOpMode extends OpMode {
         initializeMotorVariables(hardwareRoot);
         initializeServoVariables(hardwareRoot);
         initializeCRServoVariables(hardwareRoot);
+        initializeColorSensorVariables(hardwareRoot);
     }
 
     /**
@@ -135,6 +137,7 @@ public class HardwareOpMode extends OpMode {
      */
     private void updateHardware(CustomVariable hardwareRoot) {
         updateMotorStateVariables(hardwareRoot);
+        updateColorSensorStateVariables(hardwareRoot);
     }
 
     /* -------------------- Motor Handling --------------------- */
@@ -431,6 +434,72 @@ public class HardwareOpMode extends OpMode {
         ConfigVariable<?> runModeVar = config.getVariable("Power");
         if (runModeVar != null) {
             servo.setPower((Double) runModeVar.getValue());
+        }
+    }
+
+    /* -------------------- Color Sensor Handling --------------------- */
+    /**
+     * Discovers all Color Sensors in the hardware map and creates dashboard variables for them.
+     * Each sensor gets variables for RGB and port information.
+     *
+     * @param hardwareRoot the root variable container to add color sensor variables to
+     */
+    private void initializeColorSensorVariables(CustomVariable hardwareRoot) {
+        CustomVariable colorSensors = new CustomVariable();
+
+        for (ColorSensor colorSensor : hardwareMap.getAll(ColorSensor.class)) {
+            String deviceName = getDeviceName(colorSensor);
+            if (deviceName == null) continue;
+
+            colorSensors.putVariable(deviceName, createColorSensorVariable(colorSensor));
+        }
+
+        hardwareRoot.putVariable("Color Sensors", colorSensors);
+    }
+
+    /**
+     * Creates a complete dashboard variable structure for a single color sensor.
+     * Includes RGB and port information.
+     *
+     * @param colorSensor the color sensor to create variables for
+     * @return a CustomVariable containing Color Sensor-related dashboard controls and info
+     */
+    private CustomVariable createColorSensorVariable(ColorSensor colorSensor) {
+        CustomVariable colorSensorVar = new CustomVariable();
+        String hubType = extractHubType(colorSensor.getConnectionInfo());
+
+        colorSensorVar.putVariable("Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+        colorSensorVar.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+        colorSensorVar.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+
+        colorSensorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.getConnectionInfo())));
+
+        return colorSensorVar;
+    }
+
+    /**
+     * Updates the dashboard with current color sensor telemetry data.
+     * Refreshes color readings for all color sensors.
+     *
+     * @param hardwareRoot the root variable container to update with color sensor telemetry
+     */
+    private void updateColorSensorStateVariables(CustomVariable hardwareRoot) {
+        CustomVariable colorSensorsVar = (CustomVariable) hardwareRoot.getVariable("Color Sensors");
+        if (colorSensorsVar == null) return;
+
+        for (ColorSensor colorSensor : hardwareMap.getAll(ColorSensor.class)) {
+            String deviceName = getDeviceName(colorSensor);
+            if (deviceName == null) continue;
+
+            CustomVariable stateUpdate = new CustomVariable();
+            stateUpdate.putVariable("Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+            stateUpdate.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+            stateUpdate.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+
+            CustomVariable existingConfig = (CustomVariable) colorSensorsVar.getVariable(deviceName);
+            if (existingConfig != null) {
+                existingConfig.update(stateUpdate);
+            }
         }
     }
 

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
@@ -474,18 +474,7 @@ public class HardwareOpMode extends OpMode {
         CustomVariable colorSensorVar = new CustomVariable();
         String hubType = extractHubType(colorSensor.getConnectionInfo());
 
-        colorSensorVar.putVariable("Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
-        colorSensorVar.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
-        colorSensorVar.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
-
-        // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
-        if (colorSensor instanceof NormalizedColorSensor) {
-            NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
-            NormalizedRGBA reading = normColorSensor.getNormalizedColors();
-            colorSensorVar.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.red)));
-            colorSensorVar.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.green)));
-            colorSensorVar.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.blue)));
-        }
+        getColorSensorState(colorSensor, colorSensorVar);
 
         colorSensorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, extractI2CPort(colorSensor.getConnectionInfo())));
 
@@ -507,23 +496,27 @@ public class HardwareOpMode extends OpMode {
             if (deviceName == null) continue;
 
             CustomVariable stateUpdate = new CustomVariable();
-            stateUpdate.putVariable("Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
-            stateUpdate.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
-            stateUpdate.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
-
-            // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
-            if (colorSensor instanceof NormalizedColorSensor) {
-                NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
-                NormalizedRGBA reading = normColorSensor.getNormalizedColors();
-                stateUpdate.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.red)));
-                stateUpdate.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.green)));
-                stateUpdate.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.blue)));
-            }
+            getColorSensorState(colorSensor, stateUpdate);
 
             CustomVariable existingConfig = (CustomVariable) colorSensorsVar.getVariable(deviceName);
             if (existingConfig != null) {
                 existingConfig.update(stateUpdate);
             }
+        }
+    }
+
+    private void getColorSensorState(ColorSensor colorSensor, CustomVariable stateVariable) {
+        stateVariable.putVariable("Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+        stateVariable.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.green())));
+        stateVariable.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.blue())));
+
+        // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
+        if (colorSensor instanceof NormalizedColorSensor) {
+            NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
+            NormalizedRGBA reading = normColorSensor.getNormalizedColors();
+            stateVariable.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.red)));
+            stateVariable.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.green)));
+            stateVariable.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(reading.blue)));
         }
     }
 

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
@@ -16,6 +16,7 @@ import com.qualcomm.robotcore.hardware.ColorSensor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareDevice;
+import com.qualcomm.robotcore.hardware.NormalizedColorSensor;
 import com.qualcomm.robotcore.hardware.Servo;
 
 /**
@@ -476,6 +477,14 @@ public class HardwareOpMode extends OpMode {
         colorSensorVar.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
         colorSensorVar.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
 
+        // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
+        if (colorSensor instanceof NormalizedColorSensor) {
+            NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
+            colorSensorVar.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().red)));
+            colorSensorVar.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().green)));
+            colorSensorVar.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().blue)));
+        }
+
         colorSensorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.getConnectionInfo())));
 
         return colorSensorVar;
@@ -499,6 +508,14 @@ public class HardwareOpMode extends OpMode {
             stateUpdate.putVariable("Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
             stateUpdate.putVariable("Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
             stateUpdate.putVariable("Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(colorSensor.red())));
+
+            // Additional handling for preferred methods implemented by common sensors i.e. Rev V3
+            if (colorSensor instanceof NormalizedColorSensor) {
+                NormalizedColorSensor normColorSensor = (NormalizedColorSensor) colorSensor;
+                stateUpdate.putVariable("Normalized Red", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().red)));
+                stateUpdate.putVariable("Normalized Green", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().green)));
+                stateUpdate.putVariable("Normalized Blue", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(normColorSensor.getNormalizedColors().blue)));
+            }
 
             CustomVariable existingConfig = (CustomVariable) colorSensorsVar.getVariable(deviceName);
             if (existingConfig != null) {

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/hardware/HardwareOpMode.java
@@ -197,6 +197,8 @@ public class HardwareOpMode extends OpMode {
         motorVar.putVariable("Current", createVariableFromValue(current));
         motorVar.putVariable(hubType + " Port", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(motor.getPortNumber())));
 
+        motorVar.putVariable("Velocity", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(motor.getVelocity())));
+
         return motorVar;
     }
 
@@ -266,6 +268,8 @@ public class HardwareOpMode extends OpMode {
             stateUpdate.putVariable("Current Position", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(motorEx.getCurrentPosition())));
             double current = Math.round(motorEx.getCurrent(AMPS) * 100) / 100.0;
             stateUpdate.putVariable("Current", createVariableFromValue(current));
+
+            stateUpdate.putVariable("Velocity", createVariableFromValue(VariableType.READONLY_STRING, String.valueOf(motorEx.getVelocity())));
 
             CustomVariable existingConfig = (CustomVariable) motorsVar.getVariable(deviceName);
             if (existingConfig != null) {


### PR DESCRIPTION
This PR adds a section to the Hardware view displaying telemetry data from color sensors on the robot. If the color sensor is capable of providing normalized values, as many common ones are, it will display them too.

Also, there's a quick tweak to display the velocity of the motors as well. This is read-only to avoid a mess between conflicting power and velocity settings.