### PR TITLE
Add Limelight 3A proxy and dashboard view

### DIFF
--- a/FtcDashboard/build.gradle
+++ b/FtcDashboard/build.gradle
@@ -17,7 +17,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
         //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 26
     }

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -17,6 +17,7 @@ import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.dashboard.config.ValueProvider;
 import com.acmerobotics.dashboard.config.reflection.ReflectionConfig;
 import com.acmerobotics.dashboard.config.variable.CustomVariable;
+import com.acmerobotics.dashboard.limelight.LimelightProxyManager;
 import com.acmerobotics.dashboard.OpModeInfo;
 import com.acmerobotics.dashboard.message.Message;
 import com.acmerobotics.dashboard.message.redux.DeleteHardwareConfig;
@@ -244,6 +245,8 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
 
     private RobotConfigFileManager hardwareConfigManager = new RobotConfigFileManager();
     private final Mutex<SortedMap<String, RobotConfigFile>> hardwareConfigList = new Mutex<>(new TreeMap<>());
+
+    private final LimelightProxyManager limelightProxyManager = new LimelightProxyManager();
 
     private static class OpModeAndStatus {
         public OpMode opMode;
@@ -1218,6 +1221,8 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
         logcatMonitorRunnable = new LogcatMonitorRunnable();
         logcatMonitorExecutor.submit(logcatMonitorRunnable);
 
+        limelightProxyManager.start();
+
         core.enabled = true;
 
         updateStatusView();
@@ -1240,6 +1245,8 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
         }
 
         stopCameraStream();
+
+        limelightProxyManager.stop();
 
         core.enabled = false;
 

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/HttpForwarder.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/HttpForwarder.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * the Limelight MJPEG feed on port 5800).
  */
 class HttpForwarder extends NanoHTTPD {
-    private static final String TAG = "dashboard:HttpFwd";
+    private static final String TAG = "FtcDashboard";
 
     private final String targetHost;
     private final int targetPort;

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/HttpForwarder.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/HttpForwarder.java
@@ -1,0 +1,164 @@
+package com.acmerobotics.dashboard.limelight;
+
+import com.qualcomm.robotcore.util.RobotLog;
+
+import fi.iki.elonen.NanoHTTPD;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * NanoHTTPD server that forwards HTTP requests to an internal host.
+ * <p>
+ * When {@code stream} is false the full response body is buffered before replying
+ * (suitable for REST/HTML endpoints).  When {@code stream} is true the response is
+ * sent as a chunked transfer so the client receives bytes as they arrive (needed for
+ * the Limelight MJPEG feed on port 5800).
+ */
+class HttpForwarder extends NanoHTTPD {
+    private static final String TAG = "dashboard:HttpFwd";
+
+    private final String targetHost;
+    private final int targetPort;
+    private final boolean stream;
+
+    /**
+     * @param listenPort port this server binds to on the Control Hub
+     * @param targetHost host to forward to (e.g. {@code "172.29.0.1"})
+     * @param targetPort port on the target host
+     * @param stream     if true, use chunked transfer (for MJPEG); if false, buffer the full body
+     */
+    HttpForwarder(int listenPort, String targetHost, int targetPort, boolean stream) {
+        super(listenPort);
+        this.targetHost = targetHost;
+        this.targetPort = targetPort;
+        this.stream = stream;
+    }
+
+    /* ----- NanoHTTPD entry point ----- */
+
+    @Override
+    public Response serve(IHTTPSession session) {
+        // CORS preflight
+        if (session.getMethod() == Method.OPTIONS) {
+            return corsResponse(newFixedLengthResponse(Response.Status.OK, MIME_PLAINTEXT, ""));
+        }
+
+        try {
+            return forwardRequest(session);
+        } catch (Exception e) {
+            RobotLog.ww(TAG, "forward %d→%s:%d failed: %s",
+                    getListeningPort(), targetHost, targetPort, e.getMessage());
+            return newFixedLengthResponse(Response.Status.INTERNAL_ERROR,
+                    MIME_PLAINTEXT, "proxy error");
+        }
+    }
+
+    /* ----- core forwarding logic ----- */
+
+    private Response forwardRequest(IHTTPSession session) throws IOException {
+        // Open a connection to the Limelight
+        URL url = new URL("http", targetHost, targetPort, session.getUri());
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(session.getMethod().name());
+        conn.setInstanceFollowRedirects(true);
+        conn.setConnectTimeout(3000);
+
+        // Copy request headers (skip Host, Content-Length, and Accept-Encoding so that
+        // HttpURLConnection handles gzip decompression transparently instead of passing
+        // compressed bytes through without the matching Content-Encoding header)
+        for (Map.Entry<String, String> h : session.getHeaders().entrySet()) {
+            String key = h.getKey();
+            if ("host".equalsIgnoreCase(key)
+                    || "content-length".equalsIgnoreCase(key)
+                    || "accept-encoding".equalsIgnoreCase(key)) continue;
+            conn.setRequestProperty(key, h.getValue());
+        }
+
+        // Copy request body for write methods
+        if (hasBody(session.getMethod())) {
+            conn.setDoOutput(true);
+            int len = bodyLength(session);
+            if (len > 0) {
+                byte[] buf = new byte[len];
+                readFully(session.getInputStream(), buf, len);
+                conn.getOutputStream().write(buf);
+            }
+        }
+
+        // Read response
+        int code = conn.getResponseCode();
+        String contentType = conn.getContentType();
+        if (contentType == null) contentType = "application/octet-stream";
+
+        Response.IStatus status = Response.Status.lookup(code);
+        if (status == null) status = Response.Status.INTERNAL_ERROR;
+
+        Response resp;
+        if (stream) {
+            // Streaming mode: pipe the InputStream without buffering (MJPEG)
+            InputStream bodyStream = conn.getInputStream();
+            resp = newChunkedResponse(status, contentType, bodyStream);
+        } else {
+            // Buffered mode: read everything, close connection, then respond
+            byte[] body = readAllBytes(conn);
+            conn.disconnect();
+            resp = newFixedLengthResponse(status, contentType,
+                    new ByteArrayInputStream(body), body.length);
+        }
+
+        return corsResponse(resp);
+    }
+
+    /* ----- helpers ----- */
+
+    private static boolean hasBody(Method m) {
+        return m == Method.POST || m == Method.PUT || m == Method.PATCH;
+    }
+
+    private static int bodyLength(IHTTPSession session) {
+        String cl = session.getHeaders().get("content-length");
+        if (cl == null) return 0;
+        try { return Integer.parseInt(cl); }
+        catch (NumberFormatException e) { return 0; }
+    }
+
+    private static void readFully(InputStream in, byte[] buf, int len) throws IOException {
+        int off = 0;
+        while (off < len) {
+            int n = in.read(buf, off, len - off);
+            if (n < 0) break;
+            off += n;
+        }
+    }
+
+    private static byte[] readAllBytes(HttpURLConnection conn) throws IOException {
+        InputStream in;
+        try {
+            in = conn.getInputStream();
+        } catch (IOException e) {
+            in = conn.getErrorStream();
+            if (in == null) return new byte[0];
+        }
+
+        byte[] buf = new byte[4096];
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            out.write(buf, 0, n);
+        }
+        in.close();
+        return out.toByteArray();
+    }
+
+    private static Response corsResponse(Response resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "*");
+        resp.addHeader("Access-Control-Allow-Methods", "*");
+        resp.addHeader("Access-Control-Allow-Headers", "*");
+        return resp;
+    }
+}

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/LimelightProxyManager.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/LimelightProxyManager.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  * the Control Hub's Wi-Fi address.
  */
 public class LimelightProxyManager {
-    private static final String TAG = "dashboard:LLProxy";
+    private static final String TAG = "FtcDashboard";
     private static final String LL_ADDR = "172.29.0.1";
 
     private HttpForwarder mjpegForwarder;   // :5800  (streamed)

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/LimelightProxyManager.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/LimelightProxyManager.java
@@ -1,0 +1,67 @@
+package com.acmerobotics.dashboard.limelight;
+
+import com.qualcomm.robotcore.util.RobotLog;
+
+import java.io.IOException;
+
+/**
+ * Opens a set of local servers on the Control Hub that forward traffic to the
+ * Limelight 3A sitting on the internal USB-Ethernet network at 172.29.0.1.
+ * <p>
+ * The Limelight exposes several services the dashboard client needs:
+ * <ul>
+ *   <li><b>5800</b> – MJPEG camera stream (HTTP, chunked)</li>
+ *   <li><b>5801</b> – Web dashboard UI (HTTP)</li>
+ *   <li><b>5805</b> – WebSocket interface (raw TCP)</li>
+ *   <li><b>5807</b> – REST API for status &amp; config (HTTP)</li>
+ * </ul>
+ * Because the Limelight's subnet isn't routable from the browser, these
+ * forwarders let the client reach every service at the same port numbers on
+ * the Control Hub's Wi-Fi address.
+ */
+public class LimelightProxyManager {
+    private static final String TAG = "dashboard:LLProxy";
+    private static final String LL_ADDR = "172.29.0.1";
+
+    private HttpForwarder mjpegForwarder;   // :5800  (streamed)
+    private HttpForwarder dashForwarder;    // :5801  (buffered)
+    private TcpForwarder  wsForwarder;      // :5805  (raw TCP)
+    private HttpForwarder apiForwarder;     // :5807  (buffered)
+
+    private boolean running;
+
+    public synchronized void start() {
+        if (running) return;
+
+        mjpegForwarder = new HttpForwarder(5800, LL_ADDR, 5800, /* stream */ true);
+        dashForwarder  = new HttpForwarder(5801, LL_ADDR, 5801, /* stream */ false);
+        wsForwarder    = new TcpForwarder (5805, LL_ADDR, 5805);
+        apiForwarder   = new HttpForwarder(5807, LL_ADDR, 5807, /* stream */ false);
+
+        try { mjpegForwarder.start(); } catch (IOException e) { logFail(5800, e); }
+        try { dashForwarder.start();  } catch (IOException e) { logFail(5801, e); }
+        wsForwarder.open();
+        try { apiForwarder.start();   } catch (IOException e) { logFail(5807, e); }
+
+        running = true;
+        RobotLog.ii(TAG, "Limelight forwarders started");
+    }
+
+    public synchronized void stop() {
+        if (!running) return;
+
+        if (mjpegForwarder != null) mjpegForwarder.stop();
+        if (dashForwarder  != null) dashForwarder.stop();
+        if (wsForwarder    != null) wsForwarder.close();
+        if (apiForwarder   != null) apiForwarder.stop();
+
+        running = false;
+        RobotLog.ii(TAG, "Limelight forwarders stopped");
+    }
+
+    public boolean isRunning() { return running; }
+
+    private static void logFail(int port, IOException e) {
+        RobotLog.ww(TAG, "could not bind :%d – %s", port, e.getMessage());
+    }
+}

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/TcpForwarder.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/TcpForwarder.java
@@ -18,7 +18,7 @@ import java.net.SocketException;
  * the browser through the Control Hub.
  */
 class TcpForwarder {
-    private static final String TAG = "dashboard:TcpFwd";
+    private static final String TAG = "FtcDashboard";
 
     private final int listenPort;
     private final String targetHost;

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/TcpForwarder.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/limelight/TcpForwarder.java
@@ -1,0 +1,115 @@
+package com.acmerobotics.dashboard.limelight;
+
+import com.qualcomm.robotcore.util.RobotLog;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+
+/**
+ * Bidirectional TCP forwarder.  Every connection accepted on {@code listenPort}
+ * is paired with a new connection to {@code targetHost:targetPort} and bytes
+ * are shuttled in both directions until either side closes.
+ * <p>
+ * This is used to make the Limelight's WebSocket (port 5805) reachable from
+ * the browser through the Control Hub.
+ */
+class TcpForwarder {
+    private static final String TAG = "dashboard:TcpFwd";
+
+    private final int listenPort;
+    private final String targetHost;
+    private final int targetPort;
+
+    private volatile boolean alive;
+    private ServerSocket serverSocket;
+    private Thread acceptThread;
+
+    TcpForwarder(int listenPort, String targetHost, int targetPort) {
+        this.listenPort = listenPort;
+        this.targetHost = targetHost;
+        this.targetPort = targetPort;
+    }
+
+    synchronized void open() {
+        if (alive) return;
+        alive = true;
+
+        acceptThread = new Thread(() -> acceptLoop(), "TcpFwd-" + listenPort);
+        acceptThread.setDaemon(true);
+        acceptThread.start();
+    }
+
+    synchronized void close() {
+        if (!alive) return;
+        alive = false;
+
+        try {
+            if (serverSocket != null) serverSocket.close();
+        } catch (IOException ignored) { }
+
+        if (acceptThread != null) {
+            acceptThread.interrupt();
+        }
+    }
+
+    /* ---- internals ---- */
+
+    private void acceptLoop() {
+        try {
+            serverSocket = new ServerSocket(listenPort);
+            RobotLog.ii(TAG, "listening on :%d → %s:%d", listenPort, targetHost, targetPort);
+
+            while (alive) {
+                Socket client = serverSocket.accept();
+                Thread t = new Thread(() -> bridge(client), "TcpBridge-" + listenPort);
+                t.setDaemon(true);
+                t.start();
+            }
+        } catch (SocketException e) {
+            if (alive) RobotLog.ww(TAG, "accept error on :%d: %s", listenPort, e.getMessage());
+        } catch (IOException e) {
+            RobotLog.ee(TAG, "server socket error on :%d: %s", listenPort, e.getMessage());
+        }
+    }
+
+    /**
+     * Connects to the target and copies bytes in both directions until either
+     * side disconnects.
+     */
+    private void bridge(Socket client) {
+        try (Socket remote = new Socket(targetHost, targetPort)) {
+            Thread toRemote = copyAsync(client.getInputStream(), remote.getOutputStream(),
+                    "c→r:" + listenPort);
+            Thread toClient = copyAsync(remote.getInputStream(), client.getOutputStream(),
+                    "r→c:" + listenPort);
+
+            // Wait for either direction to finish (= connection closed by one side)
+            toRemote.join();
+            toClient.join();
+        } catch (IOException | InterruptedException e) {
+            // Typical when one side drops the connection – no action needed.
+        } finally {
+            try { client.close(); } catch (IOException ignored) { }
+        }
+    }
+
+    private static Thread copyAsync(InputStream in, OutputStream out, String name) {
+        Thread t = new Thread(() -> {
+            byte[] buf = new byte[8192];
+            try {
+                int n;
+                while ((n = in.read(buf)) >= 0) {
+                    out.write(buf, 0, n);
+                    out.flush();
+                }
+            } catch (IOException ignored) { }
+        }, name);
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+}

--- a/client/src/components/ConfigurableLayout/ConfigurableLayout.tsx
+++ b/client/src/components/ConfigurableLayout/ConfigurableLayout.tsx
@@ -25,6 +25,7 @@ import OpModeView from '@/components/views/OpModeView';
 import LoggingView from '@/components/views/LoggingView/LoggingView';
 import HardwareConfigView from '@/components/views/HardwareConfigView/HardwareConfigView';
 import ErrorView from '@/components/views/ErrorView/ErrorView';
+import LimelightView from '@/components/views/LimelightView';
 
 import RadialFab from './RadialFab/RadialFab';
 import RadialFabChild from './RadialFab/RadialFabChild';
@@ -74,6 +75,7 @@ const VIEW_MAP: { [key in ConfigurableView]: ReactElement } = {
   [ConfigurableView.LOGGING_VIEW]: <LoggingView />,
   [ConfigurableView.HARDWARE_CONFIG_VIEW]: <HardwareConfigView />,
   [ConfigurableView.ERROR_VIEW]: <ErrorView />,
+  [ConfigurableView.LIMELIGHT_VIEW]: <LimelightView />,
 };
 
 const LOCAL_STORAGE_LAYOUT_KEY = 'configurableLayoutStorage';

--- a/client/src/components/ConfigurableLayout/ViewPicker.tsx
+++ b/client/src/components/ConfigurableLayout/ViewPicker.tsx
@@ -145,6 +145,13 @@ const listContent = [
     customStyles: 'focus:ring-red-600',
     iconBg: 'bg-red-500',
   },
+  {
+    title: 'Limelight View',
+    view: ConfigurableView.LIMELIGHT_VIEW,
+    icon: <CameraIcon className="h-5 w-5 text-white" />,
+    customStyles: 'focus:ring-lime-600',
+    iconBg: 'bg-lime-500',
+  },
 ];
 
 const ViewPicker = (props: ViewPickerProps) => {

--- a/client/src/components/views/LimelightView.tsx
+++ b/client/src/components/views/LimelightView.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store/reducers';
+import BaseView, {
+  BaseViewHeading,
+  BaseViewBody,
+  BaseViewIcons,
+  BaseViewIconButton,
+} from './BaseView';
+import { ReactComponent as RefreshIcon } from '@/assets/icons/refresh.svg';
+
+type LimelightStatus = {
+  temp: number;
+  cpu: number;
+  ram: number;
+  pipelineIndex: number;
+};
+
+function getLimelightHost(): string {
+  return import.meta.env['VITE_REACT_APP_HOST'] || window.location.hostname;
+}
+
+type LimelightViewProps = {
+  isDraggable?: boolean;
+  isUnlocked?: boolean;
+};
+
+export default function LimelightView({
+  isDraggable,
+  isUnlocked,
+}: LimelightViewProps) {
+  const isConnected = useSelector(
+    (state: RootState) => state.socket.isConnected,
+  );
+  const [available, setAvailable] = useState(false);
+  const [status, setStatus] = useState<LimelightStatus | null>(null);
+  const [showStream, setShowStream] = useState(true);
+  const [streamKey, setStreamKey] = useState(0);
+
+  const host = getLimelightHost();
+  const streamUrl = `http://${host}:5800`;
+  const dashboardUrl = `http://${host}:5801`;
+  const statusUrl = `http://${host}:5807/status`;
+
+  const checkStatus = useCallback(async () => {
+    if (!isConnected) {
+      setAvailable(false);
+      setStatus(null);
+      return;
+    }
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 2000);
+      const resp = await fetch(statusUrl, { signal: controller.signal });
+      clearTimeout(timeout);
+      if (resp.ok) {
+        const data = await resp.json();
+        setAvailable(true);
+        setStatus(data);
+      } else {
+        setAvailable(false);
+        setStatus(null);
+      }
+    } catch {
+      setAvailable(false);
+      setStatus(null);
+    }
+  }, [isConnected, statusUrl]);
+
+  useEffect(() => {
+    checkStatus();
+    const interval = setInterval(checkStatus, 2000);
+    return () => clearInterval(interval);
+  }, [checkStatus]);
+
+  return (
+    <BaseView isUnlocked={isUnlocked}>
+      <div className="flex">
+        <BaseViewHeading isDraggable={isDraggable}>Limelight</BaseViewHeading>
+        <BaseViewIcons>
+          <BaseViewIconButton
+            title="Refresh stream"
+            onClick={() => setStreamKey((k) => k + 1)}
+          >
+            <RefreshIcon className="h-6 w-6" />
+          </BaseViewIconButton>
+        </BaseViewIcons>
+      </div>
+      <BaseViewBody>
+        {!isConnected ? (
+          <p className="py-4 text-center text-gray-500">
+            Not connected to robot
+          </p>
+        ) : !available ? (
+          <p className="py-4 text-center text-gray-500">
+            Limelight unavailable
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2 pb-2">
+            {/* Camera stream */}
+            {showStream ? (
+              <div className="relative w-full overflow-hidden rounded border border-gray-200 dark:border-gray-700">
+                <img
+                  key={streamKey}
+                  src={streamUrl}
+                  alt="Limelight camera feed"
+                  className="w-full"
+                  style={{ minHeight: '10rem', objectFit: 'contain' }}
+                  onError={() => setShowStream(false)}
+                />
+              </div>
+            ) : (
+              <button
+                className="rounded bg-gray-200 px-3 py-2 text-sm dark:bg-gray-700"
+                onClick={() => {
+                  setShowStream(true);
+                  setStreamKey((k) => k + 1);
+                }}
+              >
+                Retry camera stream
+              </button>
+            )}
+
+            {/* Stats */}
+            {status && (
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                {status.temp !== undefined && (
+                  <span>
+                    Temp: <strong>{status.temp.toFixed(1)}°C</strong>
+                  </span>
+                )}
+                {status.cpu !== undefined && (
+                  <span>
+                    CPU: <strong>{status.cpu.toFixed(1)}%</strong>
+                  </span>
+                )}
+                {status.ram !== undefined && (
+                  <span>
+                    RAM: <strong>{status.ram.toFixed(1)}%</strong>
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Open dashboard button */}
+            <a
+              href={dashboardUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block rounded bg-primary-600 px-4 py-2 text-center text-sm text-white hover:bg-primary-700"
+            >
+              Open Limelight Dashboard
+            </a>
+          </div>
+        )}
+      </BaseViewBody>
+    </BaseView>
+  );
+}

--- a/client/src/components/views/LimelightView.tsx
+++ b/client/src/components/views/LimelightView.tsx
@@ -48,22 +48,19 @@ export default function LimelightView({
       setStatus(null);
       return;
     }
+    let available = false;
+    let data: LimelightStatus | null = null;
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 2000);
       const resp = await fetch(statusUrl, { signal: controller.signal });
       clearTimeout(timeout);
-      if (resp.ok) {
-        const data = await resp.json();
-        setAvailable(true);
-        setStatus(data);
-      } else {
-        setAvailable(false);
-        setStatus(null);
-      }
-    } catch {
-      setAvailable(false);
-      setStatus(null);
+      if (!resp.ok) return;
+      data = await resp.json();
+      available = true;
+    } finally {
+      setAvailable(available);
+      setStatus(data);
     }
   }, [isConnected, statusUrl]);
 

--- a/client/src/enums/ConfigurableView.ts
+++ b/client/src/enums/ConfigurableView.ts
@@ -10,4 +10,5 @@ export enum ConfigurableView {
   LOGGING_VIEW,
   HARDWARE_CONFIG_VIEW,
   ERROR_VIEW,
+  LIMELIGHT_VIEW,
 }


### PR DESCRIPTION
Adds support for viewing and interacting with a Limelight 3A through the FTC Dashboard on the Control Hub.
- Adds proxy servers on the Control Hub that forward the Limelight's MJPEG stream (:5800), web UI (:5801), WebSocket (:5805), and REST API (:5807) to the browser over Wi-Fi
- Adds a Limelight view to the custom layout view picker that displays a live camera feed, real-time device stats (CPU, RAM, temperature), and a link to open the full Limelight web dashboard
- Unrelated fix: Bumps minSdkVersion from 23 to 24 to satisfy FTC SDK v11's RobotCore AAR, which declares minSdkVersion 24 in its manifest and caused a manifest merger build failure after the SDK v10.3.0 → v11.0.0 upgrade

https://github.com/user-attachments/assets/81f06eba-3291-4d2b-9314-f04a7e4d6ce4

