### PR TITLE
Add opt-in battery current monitoring

### DIFF
--- a/.claude/settings.local.json.tmp.18512.6ad9c246a57b
+++ b/.claude/settings.local.json.tmp.18512.6ad9c246a57b
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash('/c/Program Files/Android/Android Studio/jbr/bin/javap.exe' -classpath /c/Users/haoke/AppData/Local/Temp/claude/C--Users-haoke-OneDrive-Documents-ftc-dashboard/164f6597-9070-4fb8-b2dd-ac0cdcd2836a/scratchpad/sdk com.qualcomm.hardware.lynx.LynxModule)",
+      "Bash(npx tsc *)",
+      "Bash(./gradlew :DashboardCore:compileJava :FtcDashboard:compileReleaseJavaWithJavac --offline -q)",
+      "Bash(./gradlew :DashboardCore:compileTestJava --offline -q)",
+      "Bash(./gradlew :FtcDashboard:compileReleaseJavaWithJavac)",
+      "Bash(npx prettier *)",
+      "Bash(npx eslint *)",
+      "Bash(git checkout *)",
+      "Bash(git update-index *)",
+      "Bash(awk '$1==\"0\" && $2==\"0\" {print $3}')",
+      "Bash(xargs -a /tmp/nochange.txt git checkout --)",
+      "Bash(git config *)",
+      "Bash(git add *)",
+      "Bash(./gradlew :DashboardCore:test --offline -q)",
+      "Bash(echo \"EXIT=$?\")",
+      "Bash(./gradlew :DashboardCore:check)",
+      "Bash(git stash *)",
+      "Bash(./gradlew :DashboardCore:checkstyleMain)"
+    ]
+  }
+}

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/RobotStatus.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/RobotStatus.java
@@ -21,13 +21,17 @@ public class RobotStatus {
     private String warningMessage;
     private String errorMessage;
     private double batteryVoltage;
+    /**
+     * Total current draw in amps, or -1 if current monitoring is disabled.
+     */
+    private double batteryCurrent;
 
     /**
      * Creates a status object with the default values.
      */
     public RobotStatus(boolean enabled, boolean available, String activeOpMode,
                        OpModeStatus activeOpModeStatus, String warningMessage,
-                       String errorMessage, double batteryVoltage) {
+                       String errorMessage, double batteryVoltage, double batteryCurrent) {
         this.enabled = enabled;
         this.available = available;
         this.activeOpMode = activeOpMode;
@@ -35,5 +39,6 @@ public class RobotStatus {
         this.warningMessage = warningMessage;
         this.errorMessage = errorMessage;
         this.batteryVoltage = batteryVoltage;
+        this.batteryCurrent = batteryCurrent;
     }
 }

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/MessageType.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/MessageType.java
@@ -14,6 +14,7 @@ import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
 import com.acmerobotics.dashboard.message.redux.ReceiveTelemetry;
 import com.acmerobotics.dashboard.message.redux.SaveConfig;
+import com.acmerobotics.dashboard.message.redux.SetCurrentEnabled;
 import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.message.redux.WriteHardwareConfig;
 import com.acmerobotics.dashboard.message.redux.DeleteHardwareConfig;
@@ -27,6 +28,7 @@ public enum MessageType {
     /* status (also serves as a heartbeat) */
     GET_ROBOT_STATUS(GetRobotStatus.class),
     RECEIVE_ROBOT_STATUS(ReceiveRobotStatus.class),
+    SET_CURRENT_ENABLED(SetCurrentEnabled.class),
 
     /* op mode management */
     INIT_OP_MODE(InitOpMode.class),

--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/SetCurrentEnabled.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/message/redux/SetCurrentEnabled.java
@@ -1,0 +1,22 @@
+package com.acmerobotics.dashboard.message.redux;
+
+import com.acmerobotics.dashboard.message.Message;
+import com.acmerobotics.dashboard.message.MessageType;
+
+/**
+ * Toggles battery current monitoring. Reading the current draw off each hub costs an extra
+ * round trip on the Lynx bus, so it stays off until a client asks for it.
+ */
+public class SetCurrentEnabled extends Message {
+    private boolean currentEnabled;
+
+    public SetCurrentEnabled(boolean currentEnabled) {
+        super(MessageType.SET_CURRENT_ENABLED);
+
+        this.currentEnabled = currentEnabled;
+    }
+
+    public boolean isCurrentEnabled() {
+        return currentEnabled;
+    }
+}

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -6,6 +6,7 @@ import com.acmerobotics.dashboard.message.redux.InitOpMode;
 import com.acmerobotics.dashboard.message.redux.ReceiveHardwareConfigList;
 import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
+import com.acmerobotics.dashboard.message.redux.SetCurrentEnabled;
 import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.OpModeInfo;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
@@ -31,6 +32,9 @@ public class TestDashboardInstance {
     TestRobotConfigManager hardwareConfigManager = new TestRobotConfigManager();
 
     private TelemetryPacket currentPacket;
+
+    // mirrors the flag FtcDashboard keeps for the real hubs
+    private volatile boolean currentEnabled;
 
     DashboardCore core = new DashboardCore();
 
@@ -99,6 +103,26 @@ public class TestDashboardInstance {
             opModeManager.clearSendFun();
         }
 
+        private RobotStatus getRobotStatus() {
+            String opModeName;
+            RobotStatus.OpModeStatus opModeStatus;
+            if (opModeManager.getActiveOpMode() == null) {
+                opModeName = DEFAULT_OP_MODE_NAME;
+                opModeStatus = RobotStatus.OpModeStatus.STOPPED;
+            } else {
+                opModeName = opModeManager.getActiveOpMode().getName();
+                opModeStatus = opModeManager.getActiveOpMode().getOpModeStatus();
+            }
+
+            // stand-in for the hub reading: swings so the toggle is visibly live
+            double batteryCurrent = currentEnabled
+                ? 6.0 + 3.0 * Math.sin(System.currentTimeMillis() / 2000.0)
+                : -1.0;
+
+            return new RobotStatus(core.enabled, true, opModeName, opModeStatus, "", "", 12.0,
+                batteryCurrent);
+        }
+
         @Override
         protected void onMessage(NanoWSD.WebSocketFrame message) {
             String payload = message.getTextPayload();
@@ -110,19 +134,12 @@ public class TestDashboardInstance {
 
             switch (msg.getType()) {
                 case GET_ROBOT_STATUS: {
-                    String opModeName;
-                    RobotStatus.OpModeStatus opModeStatus;
-                    if (opModeManager.getActiveOpMode() == null) {
-                        opModeName = DEFAULT_OP_MODE_NAME;
-                        opModeStatus = RobotStatus.OpModeStatus.STOPPED;
-                    } else {
-                        opModeName = opModeManager.getActiveOpMode().getName();
-                        opModeStatus = opModeManager.getActiveOpMode().getOpModeStatus();
-                    }
-
-                    send(new ReceiveRobotStatus(
-                        new RobotStatus(core.enabled, true, opModeName, opModeStatus, "", "", 12.0)
-                    ));
+                    send(new ReceiveRobotStatus(getRobotStatus()));
+                    break;
+                }
+                case SET_CURRENT_ENABLED: {
+                    currentEnabled = ((SetCurrentEnabled) msg).isCurrentEnabled();
+                    send(new ReceiveRobotStatus(getRobotStatus()));
                     break;
                 }
                 case INIT_OP_MODE: {

--- a/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
+++ b/FtcDashboard/src/main/java/com/acmerobotics/dashboard/FtcDashboard.java
@@ -28,6 +28,7 @@ import com.acmerobotics.dashboard.message.redux.ReceiveImage;
 import com.acmerobotics.dashboard.message.redux.ReceiveLogcatErrors;
 import com.acmerobotics.dashboard.message.redux.ReceiveOpModeList;
 import com.acmerobotics.dashboard.message.redux.ReceiveRobotStatus;
+import com.acmerobotics.dashboard.message.redux.SetCurrentEnabled;
 import com.acmerobotics.dashboard.message.redux.SetHardwareConfig;
 import com.acmerobotics.dashboard.message.redux.WriteHardwareConfig;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
@@ -87,6 +88,7 @@ import org.firstinspires.ftc.robotcore.external.Func;
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.function.Consumer;
 import org.firstinspires.ftc.robotcore.external.function.Continuation;
+import org.firstinspires.ftc.robotcore.external.navigation.CurrentUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.VoltageUnit;
 import org.firstinspires.ftc.robotcore.external.stream.CameraStreamSource;
 import org.firstinspires.ftc.robotcore.internal.opmode.OpModeMeta;
@@ -239,6 +241,9 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
     private long lastGamepadTimestamp;
 
     private boolean webServerAttached;
+
+    // toggled by the client; read from the socket threads that build RobotStatus
+    private volatile boolean currentEnabled;
 
     private TextView connectionStatusTextView;
     private LinearLayout parentLayout;
@@ -1065,6 +1070,11 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                     send(new ReceiveRobotStatus(getRobotStatus()));
                     break;
                 }
+                case SET_CURRENT_ENABLED: {
+                    currentEnabled = ((SetCurrentEnabled) msg).isCurrentEnabled();
+                    send(new ReceiveRobotStatus(getRobotStatus()));
+                    break;
+                }
                 case INIT_OP_MODE: {
                     String opModeName = ((InitOpMode) msg).getOpModeName();
                     opModeManager.initOpMode(opModeName);
@@ -1791,14 +1801,21 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
     private RobotStatus getRobotStatus() {
         if (opModeManager == null) {
             return new RobotStatus(core.enabled, false, "", RobotStatus.OpModeStatus.STOPPED, "",
-                "", -1.0);
+                "", -1.0, -1.0);
         } else {
             return activeOpMode.with(o -> {
                 double batteryVoltage = -1.0;
+                // Polling the current costs an extra Lynx round trip per hub, so only pay for it
+                // while a client is actually showing the reading.
+                double batteryCurrent = currentEnabled ? 0.0 : -1.0;
                 if (o.opMode.hardwareMap != null) {
                     for (LynxModule m : o.opMode.hardwareMap.getAll(LynxModule.class)) {
                         batteryVoltage =
                             Math.max(batteryVoltage, m.getInputVoltage(VoltageUnit.VOLTS));
+
+                        if (currentEnabled) {
+                            batteryCurrent += m.getCurrent(CurrentUnit.AMPS);
+                        }
                     }
                 }
 
@@ -1807,7 +1824,7 @@ public class FtcDashboard implements OpModeManagerImpl.Notifications {
                     // status is an enum so it's okay to return a copy here.
                     o.status,
                     RobotLog.getGlobalWarningMessage().message, RobotLog.getGlobalErrorMsg(),
-                    batteryVoltage
+                    batteryVoltage, batteryCurrent
                 );
             });
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DriveTestOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DriveTestOpMode.java
@@ -1,0 +1,96 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+/*
+ * Timed mecanum drive: forward, pause, reverse. Useful for putting a real load on the battery
+ * while watching the dashboard's voltage and current readouts.
+ */
+@Config
+@Autonomous
+public class DriveTestOpMode extends LinearOpMode {
+    public static double DRIVE_POWER = 0.4;
+
+    public static double FORWARD_SECONDS = 1.0;
+    public static double PAUSE_SECONDS = 2.0;
+    public static double REVERSE_SECONDS = 1.0;
+
+    private DcMotor frontLeft;
+    private DcMotor frontRight;
+    private DcMotor backLeft;
+    private DcMotor backRight;
+
+    @Override
+    public void runOpMode() throws InterruptedException {
+        telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
+
+        frontLeft = hardwareMap.get(DcMotor.class, "fl");
+        frontRight = hardwareMap.get(DcMotor.class, "fr");
+        backLeft = hardwareMap.get(DcMotor.class, "bl");
+        backRight = hardwareMap.get(DcMotor.class, "br");
+
+        // Left motors are mirrored on a typical mecanum chassis. If the robot spins in place
+        // instead of driving straight, flip these two.
+        frontLeft.setDirection(DcMotorSimple.Direction.REVERSE);
+        backLeft.setDirection(DcMotorSimple.Direction.REVERSE);
+        frontRight.setDirection(DcMotorSimple.Direction.FORWARD);
+        backRight.setDirection(DcMotorSimple.Direction.FORWARD);
+
+        for (DcMotor motor : new DcMotor[] {frontLeft, frontRight, backLeft, backRight}) {
+            motor.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+            motor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+        }
+
+        telemetry.addLine("Ready. Put the robot on blocks or clear the area before starting.");
+        telemetry.update();
+
+        waitForStart();
+
+        if (isStopRequested()) {
+            return;
+        }
+
+        driveFor("forward", DRIVE_POWER, FORWARD_SECONDS);
+        driveFor("pause", 0.0, PAUSE_SECONDS);
+        driveFor("reverse", -DRIVE_POWER, REVERSE_SECONDS);
+
+        setDrivePower(0.0);
+
+        telemetry.addData("phase", "done");
+        telemetry.update();
+    }
+
+    /**
+     * Holds the given power on all four wheels for the given duration, bailing out early if the
+     * op mode is stopped.
+     */
+    private void driveFor(String phase, double power, double seconds) {
+        ElapsedTime timer = new ElapsedTime();
+        setDrivePower(power);
+
+        while (opModeIsActive() && timer.seconds() < seconds) {
+            telemetry.addData("phase", phase);
+            telemetry.addData("power", power);
+            telemetry.addData("elapsed", timer.seconds());
+            telemetry.update();
+
+            sleep(20);
+        }
+
+        setDrivePower(0.0);
+    }
+
+    private void setDrivePower(double power) {
+        frontLeft.setPower(power);
+        frontRight.setPower(power);
+        backLeft.setPower(power);
+        backRight.setPower(power);
+    }
+}

--- a/client/src/assets/icons/bolt.svg
+++ b/client/src/assets/icons/bolt.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="18px" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m13.5 2-8.5 12h6l-1 8 8.5-12h-6z" fill="currentColor"/>
+</svg>

--- a/client/src/components/Dashboard/Dashboard.tsx
+++ b/client/src/components/Dashboard/Dashboard.tsx
@@ -3,9 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import LayoutPreset, { LayoutPresetType } from '@/enums/LayoutPreset';
 import { saveLayoutPreset, getLayoutPreset } from '@/store/actions/settings';
+import { setCurrentEnabled } from '@/store/actions/status';
 import { RootState } from '@/store/reducers';
 
 import { BaseViewIconButton } from '@/components/views/BaseView';
+import { ReactComponent as BoltIcon } from '@/assets/icons/bolt.svg';
 import { ReactComponent as ConnectedIcon } from '@/assets/icons/connected.svg';
 import { ReactComponent as DisconnectedIcon } from '@/assets/icons/disconnected.svg';
 import { ReactComponent as SettingsIcon } from '@/assets/icons/settings.svg';
@@ -20,6 +22,12 @@ export default function Dashboard() {
   const enabled = useSelector((state: RootState) => state.status.enabled);
   const batteryVoltage = useSelector(
     (state: RootState) => state.status.batteryVoltage,
+  );
+  const batteryCurrent = useSelector(
+    (state: RootState) => state.status.batteryCurrent,
+  );
+  const currentEnabled = useSelector(
+    (state: RootState) => state.status.currentEnabled,
   );
   const dispatch = useDispatch();
 
@@ -61,14 +69,35 @@ export default function Dashboard() {
             <p
               className="mx-2"
               style={{
-                width: batteryVoltage > 0 ? '120px' : '60px',
+                width: `${
+                  60 + (batteryVoltage > 0 ? 60 : 0) + (currentEnabled ? 65 : 0)
+                }px`,
                 textAlign: 'right',
               }}
             >
               {socket.pingTime}ms
               {batteryVoltage > 0 ? ` / ${batteryVoltage.toFixed(2)}V` : ''}
+              {currentEnabled
+                ? ` / ${
+                    batteryCurrent >= 0 ? batteryCurrent.toFixed(2) : '--'
+                  }A`
+                : ''}
             </p>
           )}
+          <BaseViewIconButton
+            title={
+              currentEnabled
+                ? 'Hide current draw (stops polling the hubs)'
+                : 'Show current draw (polls the hubs, adds loop time)'
+            }
+            aria-pressed={currentEnabled}
+            className={`icon-btn ml-1 h-8 w-8 hover:border-white/50 ${
+              currentEnabled ? 'border-white/70 bg-white/20' : ''
+            }`}
+            onClick={() => dispatch(setCurrentEnabled(!currentEnabled))}
+          >
+            <BoltIcon className="h-6 w-6" />
+          </BaseViewIconButton>
           {socket.isConnected ? (
             <ConnectedIcon className="ml-4 h-10 w-10 py-1" />
           ) : (

--- a/client/src/store/actions/status.ts
+++ b/client/src/store/actions/status.ts
@@ -4,6 +4,8 @@ import {
   ReceiveRobotStatusAction,
   RECEIVE_OP_MODE_LIST,
   RECEIVE_ROBOT_STATUS,
+  SET_CURRENT_ENABLED,
+  SetCurrentEnabledAction,
   OpModeInfo,
 } from '@/store/types/status';
 
@@ -19,4 +21,11 @@ export const receiveOpModeList = (
 ): ReceiveOpModeListAction => ({
   type: RECEIVE_OP_MODE_LIST,
   opModeInfoList,
+});
+
+export const setCurrentEnabled = (
+  currentEnabled: boolean,
+): SetCurrentEnabledAction => ({
+  type: SET_CURRENT_ENABLED,
+  currentEnabled,
 });

--- a/client/src/store/middleware/socketMiddleware.ts
+++ b/client/src/store/middleware/socketMiddleware.ts
@@ -15,10 +15,13 @@ import {
   DELETE_HARDWARE_CONFIG,
   START_OP_MODE,
   STOP_OP_MODE,
+  SET_CURRENT_ENABLED,
 } from '@/store/types';
 
 let socket: WebSocket;
 let statusSentTime: number;
+// mirrored here so the robot can be re-synced after a reconnect
+let currentEnabled = false;
 
 export function startSocketWatcher(dispatch: AppThunkDispatch) {
   setInterval(() => {
@@ -36,6 +39,13 @@ export function startSocketWatcher(dispatch: AppThunkDispatch) {
 
       socket.onopen = () => {
         dispatch(receiveConnectionStatus(true));
+
+        // the robot defaults to current monitoring off, so only speak up if it's on
+        if (currentEnabled) {
+          socket.send(
+            JSON.stringify({ type: SET_CURRENT_ENABLED, currentEnabled: true }),
+          );
+        }
       };
 
       socket.onclose = () => {
@@ -56,6 +66,17 @@ const socketMiddleware: Middleware<Record<string, unknown>, RootState> =
       case RECEIVE_ROBOT_STATUS: {
         const pingTime = Date.now() - statusSentTime;
         store.dispatch(receivePingTime(pingTime));
+
+        next(action);
+
+        break;
+      }
+      case SET_CURRENT_ENABLED: {
+        currentEnabled = action.currentEnabled;
+
+        if (socket !== undefined && socket.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify(action));
+        }
 
         next(action);
 

--- a/client/src/store/reducers/status.ts
+++ b/client/src/store/reducers/status.ts
@@ -3,9 +3,11 @@ import {
   ReceiveOpModeListAction,
   ReceiveRobotStatusAction,
   GamepadSupportedStatus,
+  SetCurrentEnabledAction,
   RECEIVE_OP_MODE_LIST,
   RECEIVE_ROBOT_STATUS,
   GAMEPAD_SUPPORTED_STATUS,
+  SET_CURRENT_ENABLED,
   StatusState,
 } from '@/store/types';
 
@@ -19,6 +21,8 @@ const initialState: StatusState = {
   opModeInfoList: [],
   gamepadsSupported: true,
   batteryVoltage: -1.0,
+  batteryCurrent: -1.0,
+  currentEnabled: false,
 };
 
 const statusReducer = (
@@ -26,7 +30,8 @@ const statusReducer = (
   action:
     | ReceiveRobotStatusAction
     | ReceiveOpModeListAction
-    | GamepadSupportedStatus,
+    | GamepadSupportedStatus
+    | SetCurrentEnabledAction,
 ) => {
   switch (action.type) {
     case RECEIVE_ROBOT_STATUS:
@@ -43,6 +48,13 @@ const statusReducer = (
       return {
         ...state,
         gamepadsSupported: action.gamepadsSupported,
+      };
+    case SET_CURRENT_ENABLED:
+      return {
+        ...state,
+        currentEnabled: action.currentEnabled,
+        // drop the stale reading so nothing lingers on screen until the robot replies
+        batteryCurrent: -1.0,
       };
     default:
       return state;

--- a/client/src/store/types/index.ts
+++ b/client/src/store/types/index.ts
@@ -65,6 +65,7 @@ export {
   RECEIVE_ROBOT_STATUS,
   RECEIVE_OP_MODE_LIST,
   GAMEPAD_SUPPORTED_STATUS,
+  SET_CURRENT_ENABLED,
 } from './status';
 export type {
   StatusState,
@@ -72,6 +73,7 @@ export type {
   ReceiveRobotStatusAction,
   ReceiveOpModeListAction,
   GamepadSupportedStatus,
+  SetCurrentEnabledAction,
 } from './status';
 
 export { RECEIVE_TELEMETRY } from './telemetry';

--- a/client/src/store/types/status.ts
+++ b/client/src/store/types/status.ts
@@ -5,6 +5,7 @@ export const GET_ROBOT_STATUS = 'GET_ROBOT_STATUS';
 export const RECEIVE_ROBOT_STATUS = 'RECEIVE_ROBOT_STATUS';
 export const RECEIVE_OP_MODE_LIST = 'RECEIVE_OP_MODE_LIST';
 export const GAMEPAD_SUPPORTED_STATUS = 'GAMEPAD_SUPPORTED_STATUS';
+export const SET_CURRENT_ENABLED = 'SET_CURRENT_ENABLED';
 
 export type OpModeInfo = {
   name: string;
@@ -19,6 +20,8 @@ export type RobotStatus = {
   warningMessage: string;
   errorMessage: string;
   batteryVoltage: number;
+  /** Total current draw in amps, or -1 when current monitoring is off. */
+  batteryCurrent: number;
 };
 
 export type StatusState = {
@@ -29,8 +32,11 @@ export type StatusState = {
   warningMessage: string;
   errorMessage: string;
   batteryVoltage: number;
+  batteryCurrent: number;
   opModeInfoList: OpModeInfo[];
   gamepadsSupported: boolean;
+  /** Whether the robot has been asked to poll the current draw. */
+  currentEnabled: boolean;
 };
 
 export type GetRobotStatusAction = {
@@ -50,4 +56,9 @@ export type ReceiveOpModeListAction = {
 export type GamepadSupportedStatus = {
   type: typeof GAMEPAD_SUPPORTED_STATUS;
   gamepadsSupported: boolean;
+};
+
+export type SetCurrentEnabledAction = {
+  type: typeof SET_CURRENT_ENABLED;
+  currentEnabled: boolean;
 };

--- a/deploy-to-hub.ps1
+++ b/deploy-to-hub.ps1
@@ -1,0 +1,80 @@
+# Installs the already-built Robot Controller APK onto a Control Hub.
+# No internet or gradle needed -- run this while joined to the hub's wifi.
+#
+#   powershell -ExecutionPolicy Bypass -File .\deploy-to-hub.ps1
+#
+# Pass -Usb if the laptop is plugged into the hub's USB-C port instead of its wifi.
+
+param(
+    [switch]$Usb
+)
+
+$ErrorActionPreference = 'Stop'
+
+$adb = Join-Path $env:LOCALAPPDATA 'Android\Sdk\platform-tools\adb.exe'
+$apk = Join-Path $PSScriptRoot 'TeamCode\build\outputs\apk\debug\TeamCode-debug.apk'
+$target = '192.168.43.1:5555'
+
+if (-not (Test-Path $adb)) { throw "adb not found at $adb" }
+if (-not (Test-Path $apk)) { throw "APK not found at $apk -- build it first with .\gradlew.bat :TeamCode:assembleDebug" }
+
+Write-Host "APK: $apk" -ForegroundColor Cyan
+Write-Host "     built $((Get-Item $apk).LastWriteTime)`n" -ForegroundColor Cyan
+
+if (-not $Usb) {
+    # A stale entry from a previous session shows up as "offline" and blocks the install.
+    Write-Host 'Resetting adb and connecting over wifi...' -ForegroundColor Cyan
+    & $adb disconnect $target | Out-Null
+    & $adb kill-server   | Out-Null
+    & $adb start-server  | Out-Null
+
+    $connected = $false
+    foreach ($attempt in 1..3) {
+        $result = & $adb connect $target
+        Write-Host "  attempt ${attempt}: $result"
+        if ($result -match 'connected to') { $connected = $true; break }
+        Start-Sleep -Seconds 2
+    }
+
+    if (-not $connected) {
+        Write-Host "`nCould not reach the hub at $target." -ForegroundColor Red
+        Write-Host 'Check that this laptop is joined to the Control Hub wifi network' -ForegroundColor Red
+        Write-Host '(Driver Station -> menu -> Program & Manage shows the name and passphrase).' -ForegroundColor Red
+        exit 1
+    }
+}
+
+Write-Host "`nDevices:" -ForegroundColor Cyan
+& $adb devices -l
+
+# "offline" means adb sees the hub but the handshake never finished -- installing would fail.
+$devices = (& $adb devices) | Select-String -Pattern '\sdevice$'
+if (-not $devices) {
+    Write-Host "`nNo device in 'device' state." -ForegroundColor Red
+    Write-Host "If it says 'offline', reboot the hub and run this again." -ForegroundColor Red
+    Write-Host "If it says 'unauthorized', accept the USB debugging prompt on the device." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nInstalling (this takes a minute -- it's a 58 MB APK)..." -ForegroundColor Cyan
+$output = & $adb install -r $apk 2>&1
+$output | ForEach-Object { Write-Host "  $_" }
+
+if ($output -match 'INSTALL_FAILED_UPDATE_INCOMPATIBLE|signatures do not match') {
+    Write-Host "`nThe existing Robot Controller was signed with a different key." -ForegroundColor Yellow
+    Write-Host 'Uninstalling it and retrying. This wipes the saved hardware config.' -ForegroundColor Yellow
+    & $adb uninstall com.qualcomm.ftcrobotcontroller
+    $output = & $adb install -r $apk 2>&1
+    $output | ForEach-Object { Write-Host "  $_" }
+}
+
+if ($output -match 'Success') {
+    Write-Host "`nInstalled." -ForegroundColor Green
+    Write-Host 'Next:'
+    Write-Host '  1. Wait for the Driver Station to reconnect (~15s).'
+    Write-Host '  2. Configure Robot -> add motors named fl, fr, bl, br -> save and activate.'
+    Write-Host '  3. Open http://192.168.43.1:8080/dash and look for the bolt icon, top right.'
+} else {
+    Write-Host "`nInstall failed -- see the output above." -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
Adds a total current readout to the dashboard header, next to ping and voltage, behind a toggle. Off by default.

It's opt-in because it isn't free: LynxModule.getCurrent() blocks on a LynxGetADCCommand that bulk caching doesn't cover, so it's an extra round trip per hub per status poll. Teams who aren't looking at the number shouldn't pay for it.

Protocol: new SET_CURRENT_ENABLED message (client → robot); RobotStatus gains batteryCurrent in amps, -1.0 when off — same sentinel convention as batteryVoltage.

Robot: FtcDashboard holds a volatile boolean, and getRobotStatus() sums getCurrent() across every LynxModule. Voltage takes a Math.max in the same loop because the hubs share a rail; current sums because each hub draws its own load. The handler replies with a fresh status so the reading appears on toggle, not on the next tick.

Client: bolt button in the header with a pressed state; the readout appends  / x.xxA only while enabled. The reducer clears the stale value on toggle, and the socket middleware re-sends the flag on reconnect so the field doesn't go dead after a drop.

https://github.com/user-attachments/assets/795734f2-1d54-4acd-83cd-0e47b807feb5

