### PR TITLE
Add hover tooltip to Graph view

### DIFF
--- a/client/src/components/views/GraphView/Graph.ts
+++ b/client/src/components/views/GraphView/Graph.ts
@@ -12,6 +12,10 @@ type Options = {
   fontSize: number;
   textColor: string;
   maxTicks: number;
+  crosshairColor: string;
+  // color the hover dots are outlined with; should match the view background
+  backgroundColor: string;
+  hoverDotRadius: number;
 };
 
 import twColors from 'tailwindcss/colors';
@@ -36,6 +40,9 @@ export const DEFAULT_OPTIONS: Options = {
   fontSize: 14,
   textColor: 'rgb(50, 50, 50)',
   maxTicks: 7,
+  crosshairColor: 'rgb(120, 120, 120)',
+  backgroundColor: 'rgb(255, 255, 255)',
+  hoverDotRadius: 3.5,
 };
 
 function niceNum(range: number, round: boolean) {
@@ -143,6 +150,54 @@ type Sample = {
   value: number;
 };
 
+// index of the sample in ts (sorted ascending) whose time is closest to t
+function nearestIndex(ts: number[], t: number) {
+  let lo = 0;
+  let hi = ts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (ts[mid] < t) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  if (lo > 0 && Math.abs(ts[lo - 1] - t) <= Math.abs(ts[lo] - t)) return lo - 1;
+  return lo;
+}
+
+// format a sample for display in the hover overlay
+export function formatValue(value: number) {
+  if (!Number.isFinite(value)) return `${value}`;
+
+  const mag = Math.abs(value);
+  if (mag === 0) return '0';
+  if (mag < 1e-3 || mag >= 1e6) return value.toExponential(2);
+
+  return `${parseFloat(value.toPrecision(6))}`;
+}
+
+export type HoverEntry = {
+  name: string;
+  color: string;
+  value: number;
+  // position of the sample, in CSS pixels relative to the canvas
+  x: number;
+  y: number;
+};
+
+export type HoverInfo = {
+  // the hovered time, in telemetry time
+  timeMs: number;
+  // cursor position, in CSS pixels relative to the canvas
+  cursorX: number;
+  cursorY: number;
+  // name of the series whose line is closest to the cursor
+  nearestName: string;
+  entries: HoverEntry[];
+};
+
 // align coordinate to the nearest pixel, offset by a half pixel
 // this helps with drawing thin lines; e.g., if a line of width 1px
 // is drawn on an integer coordinate, it will be 2px wide
@@ -213,6 +268,11 @@ export default class Graph {
   beginGraphNowMs = Number.NaN; // in telemetry time
   beginRenderTimeMs = Number.NaN; // in browser time
 
+  // cursor position in CSS pixels relative to the canvas, null when not hovering
+  cursor: { x: number; y: number } | null = null;
+  // result of the last hit test; recomputed on every render
+  hover: HoverInfo | null = null;
+
   scaling: Scaling;
 
   constructor(canvas: HTMLCanvasElement, options: Options) {
@@ -241,6 +301,17 @@ export default class Graph {
 
     this.beginGraphNowMs = Number.NaN; // in telemetry time
     this.beginRenderTimeMs = Number.NaN; // in browser time
+
+    this.hover = null;
+  }
+
+  // x and y are in CSS pixels relative to the canvas; pass null to clear
+  setCursor(cursor: { x: number; y: number } | null) {
+    this.cursor = cursor;
+  }
+
+  getHover() {
+    return this.hover;
   }
 
   add(time: number, samples: Sample[][]) {
@@ -305,6 +376,8 @@ export default class Graph {
 
     // eslint-disable-next-line
     this.canvas.width = this.canvas.width; // clears the canvas
+
+    this.hover = null;
 
     if (isNaN(this.beginGraphNowMs)) return false;
 
@@ -417,6 +490,142 @@ export default class Graph {
       axis,
       graphNowMs,
     );
+
+    this.hover = this.hitTest(
+      x + axisWidth + 2 * o.padding,
+      y + o.padding,
+      graphWidth,
+      graphHeight,
+      axis,
+      graphNowMs,
+    );
+
+    if (this.hover !== null) {
+      this.renderHover(
+        x + axisWidth + 2 * o.padding,
+        y + o.padding,
+        graphWidth,
+        graphHeight,
+        this.hover,
+      );
+    }
+  }
+
+  // finds the sample of each series closest in time to the cursor
+  hitTest(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    axis: Axis,
+    graphNowMs: number,
+  ): HoverInfo | null {
+    const o = this.options;
+
+    const cursor = this.cursor;
+    if (cursor === null) return null;
+
+    if (
+      cursor.x < x ||
+      cursor.x > x + width ||
+      cursor.y < y ||
+      cursor.y > y + height
+    ) {
+      return null;
+    }
+
+    // map the cursor back onto the time axis
+    const timeMs =
+      graphNowMs - o.windowMs + scale(cursor.x - x, 0, width, 0, o.windowMs);
+
+    // don't report a value for a series that has no sample near the cursor
+    // (e.g., one that stopped reporting partway through the window)
+    const maxDeltaMs = o.windowMs / 25;
+
+    const entries: HoverEntry[] = [];
+    let nearestName = '';
+    let nearestDist = Number.MAX_VALUE;
+
+    for (const name of Object.keys(this.data)) {
+      const { ts, vs, color } = this.data[name];
+
+      if (ts.length === 0) continue;
+
+      const i = nearestIndex(ts, timeMs);
+      if (Math.abs(ts[i] - timeMs) > maxDeltaMs) continue;
+
+      const sampleY = y + scale(vs[i], axis.min, axis.max, height, 0);
+
+      entries.push({
+        name,
+        color,
+        value: vs[i],
+        x: x + scale(ts[i] - graphNowMs + o.windowMs, 0, o.windowMs, 0, width),
+        y: sampleY,
+      });
+
+      const dist = Math.abs(sampleY - cursor.y);
+      if (dist < nearestDist) {
+        nearestDist = dist;
+        nearestName = name;
+      }
+    }
+
+    if (entries.length === 0) return null;
+
+    // order the entries the way they're stacked on screen
+    entries.sort((a, b) => b.value - a.value);
+
+    return {
+      timeMs,
+      cursorX: cursor.x,
+      cursorY: cursor.y,
+      nearestName,
+      entries,
+    };
+  }
+
+  renderHover(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    hover: HoverInfo,
+  ) {
+    const o = this.options;
+
+    this.ctx.save();
+    this.ctx.beginPath();
+    this.ctx.rect(x, y, width, height);
+    this.ctx.clip();
+
+    // vertical crosshair through the cursor
+    this.ctx.strokeStyle = o.crosshairColor;
+    this.ctx.lineWidth = o.gridLineWidth / devicePixelRatio;
+    this.ctx.setLineDash([4, 4]);
+    this.ctx.beginPath();
+    fineMoveTo(this.ctx, this.scaling, hover.cursorX, y);
+    fineLineTo(this.ctx, this.scaling, hover.cursorX, y + height);
+    this.ctx.stroke();
+    this.ctx.setLineDash([]);
+
+    // mark the sample of each series at the hovered time
+    this.ctx.lineWidth = 1.5;
+    this.ctx.strokeStyle = o.backgroundColor;
+    for (const entry of hover.entries) {
+      const radius =
+        entry.name === hover.nearestName
+          ? o.hoverDotRadius + 1.5
+          : o.hoverDotRadius;
+
+      this.ctx.beginPath();
+      this.ctx.arc(entry.x, entry.y, radius, 0, 2 * Math.PI);
+      this.ctx.fillStyle = entry.color;
+      this.ctx.fill();
+      this.ctx.stroke();
+    }
+
+    this.ctx.restore();
   }
 
   renderAxisLabels(x: number, y: number, height: number, ticks: string[]) {

--- a/client/src/components/views/GraphView/GraphCanvas.jsx
+++ b/client/src/components/views/GraphView/GraphCanvas.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Graph from './Graph';
+import GraphTooltip from './GraphTooltip';
 import AutoFitCanvas from '@/components/Canvas/AutoFitCanvas';
 import { isEqual } from 'lodash';
 
@@ -10,13 +11,19 @@ class GraphCanvas extends React.Component {
     super(props);
 
     this.canvasRef = React.createRef();
+    this.containerRef = React.createRef();
 
     this.renderGraph = this.renderGraph.bind(this);
+    this.handleMouseMove = this.handleMouseMove.bind(this);
+    this.handleMouseLeave = this.handleMouseLeave.bind(this);
 
     this.unsubs = []; // unsub functions to be called to cleanup
 
     this.state = {
       graphEmpty: false,
+      hover: null,
+      containerWidth: 0,
+      containerHeight: 0,
     };
   }
 
@@ -58,12 +65,63 @@ class GraphCanvas extends React.Component {
     if (graphIsDirty) this.renderGraph();
   }
 
+  // the animation loop is stopped while paused, so hovering has to redraw itself
+  renderPausedFrame() {
+    if (!this.graph) return;
+
+    this.setState({
+      graphEmpty: !this.graph.render(this.props.pausedTime),
+      hover: this.graph.getHover(),
+    });
+  }
+
+  handleMouseMove(evt) {
+    const canvas = this.canvasRef.current;
+    const container = this.containerRef.current;
+    if (!this.graph || !canvas || !container) return;
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+
+    this.graph.setCursor({
+      x: evt.clientX - canvasRect.left,
+      y: evt.clientY - canvasRect.top,
+    });
+
+    // the graph reports hover positions in canvas space; the tooltip is
+    // positioned in container space
+    this.canvasOffset = {
+      x: canvasRect.left - containerRect.left,
+      y: canvasRect.top - containerRect.top,
+    };
+
+    this.setState({
+      containerWidth: containerRect.width,
+      containerHeight: containerRect.height,
+    });
+
+    if (this.props.paused) this.renderPausedFrame();
+  }
+
+  handleMouseLeave() {
+    if (!this.graph) return;
+
+    this.graph.setCursor(null);
+
+    if (this.props.paused) {
+      this.renderPausedFrame();
+    } else {
+      this.setState({ hover: null });
+    }
+  }
+
   renderGraph() {
     if (this.props.paused) {
       this.requestId = 0;
     } else {
       this.setState(() => ({
         graphEmpty: !this.graph.render(Date.now()),
+        hover: this.graph.getHover(),
       }));
 
       this.requestId = requestAnimationFrame(this.renderGraph);
@@ -71,10 +129,17 @@ class GraphCanvas extends React.Component {
   }
 
   render() {
+    const { hover } = this.state;
+    const offset = this.canvasOffset ?? { x: 0, y: 0 };
+
     return (
-      <div className="flex-center h-full">
+      <div className="flex-center relative h-full" ref={this.containerRef}>
         <div
-          className={`${this.state.graphEmpty ? 'hidden' : ''} h-full w-full`}
+          className={`${
+            this.state.graphEmpty ? 'hidden' : ''
+          } h-full w-full cursor-crosshair`}
+          onMouseMove={this.handleMouseMove}
+          onMouseLeave={this.handleMouseLeave}
         >
           <AutoFitCanvas
             ref={this.canvasRef}
@@ -84,6 +149,17 @@ class GraphCanvas extends React.Component {
             }}
           />
         </div>
+        {hover && (
+          <GraphTooltip
+            hover={{
+              ...hover,
+              cursorX: hover.cursorX + offset.x,
+              cursorY: hover.cursorY + offset.y,
+            }}
+            width={this.state.containerWidth}
+            height={this.state.containerHeight}
+          />
+        )}
         <div className="flex-center pointer-events-none absolute top-0 left-0 h-full w-full">
           {this.state.graphEmpty && (
             <p className="text-center">No content to graph</p>

--- a/client/src/components/views/GraphView/GraphTooltip.tsx
+++ b/client/src/components/views/GraphView/GraphTooltip.tsx
@@ -1,0 +1,75 @@
+import clsx from 'clsx';
+
+import { formatValue, HoverInfo } from './Graph';
+
+const CURSOR_OFFSET = 14;
+// rough per-row and chrome heights, used to keep the tooltip on screen without
+// having to measure it after layout
+const ROW_HEIGHT = 18;
+const CHROME_HEIGHT = 16;
+
+type GraphTooltipProps = {
+  hover: HoverInfo;
+  // dimensions of the container the tooltip is positioned within
+  width: number;
+  height: number;
+};
+
+export default function GraphTooltip({
+  hover,
+  width,
+  height,
+}: GraphTooltipProps) {
+  const { cursorX, cursorY, entries, nearestName } = hover;
+
+  // flip to the other side of the cursor when close to the right edge
+  const flip = cursorX > width / 2;
+
+  const estHeight = entries.length * ROW_HEIGHT + CHROME_HEIGHT;
+  const top = Math.min(
+    Math.max(cursorY, estHeight / 2),
+    height - estHeight / 2,
+  );
+
+  return (
+    <div
+      className={clsx(
+        'pointer-events-none absolute z-10 rounded border py-1 px-2 shadow-lg',
+        'border-gray-200 bg-white/95 text-gray-900',
+        'dark:border-slate-600 dark:bg-slate-800/95 dark:text-slate-100',
+      )}
+      style={{
+        left: cursorX + (flip ? -CURSOR_OFFSET : CURSOR_OFFSET),
+        top,
+        transform: `translate(${flip ? '-100%' : '0'}, -50%)`,
+      }}
+    >
+      <table className="border-separate" style={{ borderSpacing: '0 1px' }}>
+        <tbody>
+          {entries.map((entry) => (
+            <tr
+              key={entry.name}
+              className={clsx(
+                'text-xs leading-tight',
+                entry.name === nearestName ? 'font-bold' : 'font-medium',
+              )}
+            >
+              <td className="pr-1 align-middle">
+                <span
+                  className="inline-block h-2 w-2 rounded-full align-middle"
+                  style={{ backgroundColor: entry.color }}
+                />
+              </td>
+              <td className="whitespace-nowrap pr-3 align-middle">
+                {entry.name}
+              </td>
+              <td className="whitespace-nowrap text-right align-middle font-mono">
+                {formatValue(entry.value)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/components/views/GraphView/GraphView.tsx
+++ b/client/src/components/views/GraphView/GraphView.tsx
@@ -328,6 +328,13 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
                     textColor: isDarkMode
                       ? colors.slate[100]
                       : colors.gray[900],
+                    crosshairColor: isDarkMode
+                      ? colors.slate[300]
+                      : colors.gray[500],
+                    // matches the BaseView background (bg-white / dark:bg-slate-900)
+                    backgroundColor: isDarkMode
+                      ? colors.slate[900]
+                      : 'rgb(255, 255, 255)',
                   }}
                   paused={this.state.userPaused || this.state.opmodePaused}
                   pausedTime={this.state.pausedTime}


### PR DESCRIPTION
You could see the shape of a graphed curve but not what it was worth at any given point. Hovering the plot now shows a crosshair, marks each series' sample at that time, and displays an overlay with every series name and its value. The line closest to the cursor is bolded.

Changes
- Graph.ts — cursor tracking plus hitTest(), which maps the cursor's x onto the time axis and binary-searches each series for its nearest sample. Series with no sample near the cursor are skipped so a stalled one doesn't show a stale value. renderHover() draws the crosshair and per-series dots. Adds crosshairColor / backgroundColor / hoverDotRadius options.
- GraphTooltip.tsx (new) — the overlay. Flips left near the right edge, clamps vertically, themed for light and dark.
- GraphCanvas.jsx — mouse handlers; re-renders synchronously while paused, since the rAF loop is stopped there.
- GraphView.tsx — passes theme colors through.

Values shown are real samples, not interpolations. Hovering works live, but pausing (space / k) makes reading a specific point much easier; hover doesn't auto-pause — easy follow-up if wanted.

Testing — tsc and eslint pass. Verified in-browser against mock telemetry: reported values match the underlying samples, cursor coordinates round-trip exactly, out-of-plot positions produce nothing, leaving clears everything, and edge flip/clamp plus both themes render correctly.

https://github.com/user-attachments/assets/03c26523-2d1b-45af-a4a2-8fe3c63f6eb5

