### PR TITLE
add graph markers

### DIFF
--- a/DashboardCore/src/main/java/com/acmerobotics/dashboard/telemetry/TelemetryPacket.java
+++ b/DashboardCore/src/main/java/com/acmerobotics/dashboard/telemetry/TelemetryPacket.java
@@ -15,6 +15,7 @@ public class TelemetryPacket {
     private long timestamp;
     private SortedMap<String, String> data;
     private List<String> log;
+    private List<String> markers;
     private Canvas field;
     private Canvas fieldOverlay;
 
@@ -33,6 +34,7 @@ public class TelemetryPacket {
     public TelemetryPacket(boolean drawDefaultField) {
         data = new TreeMap<>();
         log = new ArrayList<>();
+        markers = new ArrayList<>();
         field = new Canvas();
         fieldOverlay = new Canvas();
 
@@ -80,6 +82,23 @@ public class TelemetryPacket {
      */
     public void clearLines() {
         log.clear();
+    }
+
+    /**
+     * Marks the instant of this packet with a label. Markers appear as labeled vertical lines in
+     * the Graph View.
+     *
+     * @param label
+     */
+    public void addMarker(String label) {
+        markers.add(label == null ? "" : label);
+    }
+
+    /**
+     * Clears the markers in this packet.
+     */
+    public void clearMarkers() {
+        markers.clear();
     }
 
     /**

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -273,6 +273,14 @@ public class TestDashboardInstance {
         currentPacket.put(x, o);
     }
 
+    public void addMarker(String label) {
+        if (currentPacket == null) {
+            currentPacket = new TelemetryPacket();
+        }
+
+        currentPacket.addMarker(label);
+    }
+
     public void update() {
         if (currentPacket != null) {
             core.sendTelemetryPacket(currentPacket);

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestSineWaveOpMode.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestSineWaveOpMode.java
@@ -8,6 +8,7 @@ public class TestSineWaveOpMode extends TestOpMode {
     public static double PHASE = 90;
     public static double FREQUENCY = 0.25;
 
+    private double lastX;
 
     public TestSineWaveOpMode() {
         super("TestSineWaveOpMode");
@@ -20,9 +21,18 @@ public class TestSineWaveOpMode extends TestOpMode {
 
     @Override
     protected void loop() throws InterruptedException {
-        dashboard.addData("x", AMPLITUDE * Math.sin(
+        double x = AMPLITUDE * Math.sin(
             2 * Math.PI * FREQUENCY * (System.currentTimeMillis() / 1000d) + Math.toRadians(PHASE)
-        ));
+        );
+
+        dashboard.addData("x", x);
+
+        if (lastX < 0 && x >= 0) {
+            dashboard.addMarker("rising zero");
+        }
+
+        lastX = x;
+
         dashboard.update();
         Thread.sleep(10);
     }

--- a/client/src/components/views/GraphView/Graph.ts
+++ b/client/src/components/views/GraphView/Graph.ts
@@ -12,6 +12,8 @@ type Options = {
   fontSize: number;
   textColor: string;
   maxTicks: number;
+  markerColor: string;
+  markerLineWidth: number; // device pixels
 };
 
 import twColors from 'tailwindcss/colors';
@@ -36,6 +38,8 @@ export const DEFAULT_OPTIONS: Options = {
   fontSize: 14,
   textColor: 'rgb(50, 50, 50)',
   maxTicks: 7,
+  markerColor: 'rgb(90, 90, 90)',
+  markerLineWidth: 1, // device pixels
 };
 
 function niceNum(range: number, round: boolean) {
@@ -143,6 +147,19 @@ type Sample = {
   value: number;
 };
 
+// a labeled instant in telemetry time
+export type Marker = {
+  t: number;
+  label: string;
+};
+
+type Rect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 // align coordinate to the nearest pixel, offset by a half pixel
 // this helps with drawing thin lines; e.g., if a line of width 1px
 // is drawn on an integer coordinate, it will be 2px wide
@@ -209,9 +226,14 @@ export default class Graph {
   options: Options;
 
   data: { [key: string]: { ts: number[]; vs: number[]; color: string } };
+  markers: Marker[];
 
   beginGraphNowMs = Number.NaN; // in telemetry time
   beginRenderTimeMs = Number.NaN; // in browser time
+
+  // updated on each render to support hit testing against the drawn plot
+  graphNowMs = Number.NaN; // in telemetry time
+  plotRect: Rect = { x: 0, y: 0, width: 0, height: 0 }; // CSS pixels
 
   scaling: Scaling;
 
@@ -227,6 +249,7 @@ export default class Graph {
     Object.assign(this.options, options || {});
 
     this.data = {};
+    this.markers = [];
 
     this.scaling = {
       scalingX: 1,
@@ -238,13 +261,20 @@ export default class Graph {
 
   reset() {
     this.data = {};
+    this.markers = [];
 
     this.beginGraphNowMs = Number.NaN; // in telemetry time
     this.beginRenderTimeMs = Number.NaN; // in browser time
   }
 
-  add(time: number, samples: Sample[][]) {
+  add(time: number, samples: Sample[][], markers: Marker[] = []) {
     const o = this.options;
+
+    for (const { t, label } of markers) {
+      if (isNaN(t)) continue;
+
+      this.markers.push({ t, label });
+    }
 
     for (const sample of samples) {
       const t = sample.reduce(
@@ -283,6 +313,73 @@ export default class Graph {
     }
   }
 
+  addMarker(t: number, label: string) {
+    if (isNaN(t)) return;
+
+    this.markers.push({ t, label });
+  }
+
+  removeMarker(index: number) {
+    this.markers.splice(index, 1);
+  }
+
+  // where a marker is drawn, in CSS pixels relative to the canvas
+  markerXCoord(marker: Marker) {
+    const { x, width } = this.plotRect;
+    return (
+      x +
+      scale(
+        marker.t - this.graphNowMs + this.options.windowMs,
+        0,
+        this.options.windowMs,
+        0,
+        width,
+      )
+    );
+  }
+
+  // index of the marker drawn closest to x, or -1 if none is within tolerance
+  // (both in CSS pixels relative to the canvas)
+  markerIndexAt(x: number, tolerance: number) {
+    if (this.plotRect.width === 0 || isNaN(this.graphNowMs)) return -1;
+
+    let closest = -1;
+    let closestDist = tolerance;
+    this.markers.forEach((marker, i) => {
+      const dist = Math.abs(this.markerXCoord(marker) - x);
+      if (dist > closestDist) return;
+
+      closest = i;
+      closestDist = dist;
+    });
+
+    return closest;
+  }
+
+  // converts an x coordinate in CSS pixels (relative to the canvas) to telemetry time
+  timeAtX(x: number) {
+    const o = this.options;
+    const { x: plotX, width } = this.plotRect;
+
+    if (width === 0) return Number.NaN;
+
+    return (
+      this.graphNowMs - o.windowMs + scale(x - plotX, 0, width, 0, o.windowMs)
+    );
+  }
+
+  // both coordinates are in CSS pixels relative to the canvas
+  isInPlot(x: number, y: number) {
+    const r = this.plotRect;
+    return (
+      r.width > 0 &&
+      x >= r.x &&
+      x <= r.x + r.width &&
+      y >= r.y &&
+      y <= r.y + r.height
+    );
+  }
+
   getYAxisScaling() {
     const [min, max] = Object.keys(this.data).reduce(
       (acc, k) =>
@@ -309,6 +406,7 @@ export default class Graph {
     if (isNaN(this.beginGraphNowMs)) return false;
 
     const graphNowMs = this.beginGraphNowMs + (time - this.beginRenderTimeMs);
+    this.graphNowMs = graphNowMs;
 
     // prune old samples
     for (const k of Object.keys(this.data)) {
@@ -318,6 +416,11 @@ export default class Graph {
         vs.shift();
       }
     }
+
+    // prune markers that have scrolled off the graph
+    this.markers = this.markers.filter(
+      ({ t }) => t + o.windowMs + 250 >= graphNowMs,
+    );
 
     let allEmpty = true;
     for (const { ts } of Object.values(this.data)) {
@@ -399,10 +502,19 @@ export default class Graph {
     );
 
     const graphWidth = width - axisWidth - 3 * o.padding;
+    const graphX = x + axisWidth + 2 * o.padding;
+    const graphY = y + o.padding;
+
+    this.plotRect = {
+      x: graphX,
+      y: graphY,
+      width: graphWidth,
+      height: graphHeight,
+    };
 
     this.renderGridLines(
-      x + axisWidth + 2 * o.padding,
-      y + o.padding,
+      graphX,
+      graphY,
       graphWidth,
       graphHeight,
       5,
@@ -410,13 +522,71 @@ export default class Graph {
     );
 
     this.renderGraphLines(
-      x + axisWidth + 2 * o.padding,
-      y + o.padding,
+      graphX,
+      graphY,
       graphWidth,
       graphHeight,
       axis,
       graphNowMs,
     );
+
+    this.renderMarkers(graphX, graphY, graphWidth, graphHeight, graphNowMs);
+  }
+
+  renderMarkers(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    graphNowMs: number,
+  ) {
+    const o = this.options;
+
+    if (this.markers.length === 0) return;
+
+    this.ctx.save();
+    this.ctx.translate(x, y);
+    // the path survives the save() above, so it has to be cleared before
+    // clipping; otherwise the leftover data line is folded into the clip
+    // region and its winding punches curve-shaped holes in the markers
+    this.ctx.beginPath();
+    this.ctx.rect(0, 0, width, height);
+    this.ctx.clip();
+
+    this.ctx.strokeStyle = o.markerColor;
+    this.ctx.fillStyle = o.markerColor;
+    this.ctx.lineWidth = o.markerLineWidth / devicePixelRatio;
+    this.ctx.setLineDash([4, 4]);
+    this.ctx.textAlign = 'left';
+
+    for (const { t, label } of this.markers) {
+      const markerX = scale(
+        t - graphNowMs + o.windowMs,
+        0,
+        o.windowMs,
+        0,
+        width,
+      );
+
+      if (markerX < 0 || markerX > width) continue;
+
+      this.ctx.beginPath();
+      fineMoveTo(this.ctx, this.scaling, markerX, 0);
+      fineLineTo(this.ctx, this.scaling, markerX, height);
+      this.ctx.stroke();
+
+      if (label === '') continue;
+
+      // labels read bottom-to-top alongside their line to stay legible on
+      // narrow graphs
+      this.ctx.save();
+      this.ctx.translate(markerX, height - o.keySpacing);
+      this.ctx.rotate(-Math.PI / 2);
+      this.ctx.fillText(label, o.keySpacing, o.fontSize * 0.75);
+      this.ctx.restore();
+    }
+
+    this.ctx.restore();
   }
 
   renderAxisLabels(x: number, y: number, height: number, ticks: string[]) {

--- a/client/src/components/views/GraphView/GraphCanvas.jsx
+++ b/client/src/components/views/GraphView/GraphCanvas.jsx
@@ -5,6 +5,16 @@ import Graph from './Graph';
 import AutoFitCanvas from '@/components/Canvas/AutoFitCanvas';
 import { isEqual } from 'lodash';
 
+// how close (in CSS pixels) a click must land to a marker to remove it
+const MARKER_HIT_RADIUS = 6;
+
+// approximate size of the label input, in CSS pixels; only used to keep it
+// from hanging off the edge of the canvas
+const DRAFT_WIDTH = 128;
+const DRAFT_HEIGHT = 26;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
 class GraphCanvas extends React.Component {
   constructor(props) {
     super(props);
@@ -12,11 +22,15 @@ class GraphCanvas extends React.Component {
     this.canvasRef = React.createRef();
 
     this.renderGraph = this.renderGraph.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleDraftKeydown = this.handleDraftKeydown.bind(this);
 
     this.unsubs = []; // unsub functions to be called to cleanup
 
     this.state = {
       graphEmpty: false,
+      // the marker awaiting a label from the user, if any
+      markerDraft: null,
     };
   }
 
@@ -50,12 +64,75 @@ class GraphCanvas extends React.Component {
     }
 
     if (!this.props.paused && !isEqual(this.props.data, prevProps.data)) {
-      this.graph.add(Date.now(), this.props.data);
+      this.graph.add(Date.now(), this.props.data, this.props.markers);
     }
 
     if (!this.props.paused && !this.requestId) graphIsDirty = true;
 
     if (graphIsDirty) this.renderGraph();
+  }
+
+  // the animation loop is stopped while paused, so marker edits have to be
+  // drawn by hand to show up
+  redrawIfPaused() {
+    if (this.props.paused) this.graph.render(this.props.pausedTime);
+  }
+
+  handleClick(evt) {
+    if (!this.graph) return;
+
+    const canvasRect = this.canvasRef.current.getBoundingClientRect();
+    const x = evt.clientX - canvasRect.left;
+    const y = evt.clientY - canvasRect.top;
+
+    if (!this.graph.isInPlot(x, y)) return;
+
+    const markerIndex = this.graph.markerIndexAt(x, MARKER_HIT_RADIUS);
+    if (markerIndex !== -1) {
+      this.graph.removeMarker(markerIndex);
+      this.setState({ markerDraft: null });
+      this.redrawIfPaused();
+      return;
+    }
+
+    const t = this.graph.timeAtX(x);
+    if (isNaN(t)) return;
+
+    // the draft input is positioned against the clicked element, and kept
+    // inside of it so that it stays on screen near the edges
+    const hostRect = evt.currentTarget.getBoundingClientRect();
+    this.setState({
+      markerDraft: {
+        x: clamp(
+          evt.clientX - hostRect.left,
+          0,
+          Math.max(0, hostRect.width - DRAFT_WIDTH),
+        ),
+        y: clamp(
+          evt.clientY - hostRect.top,
+          0,
+          Math.max(0, hostRect.height - DRAFT_HEIGHT),
+        ),
+        t,
+        label: '',
+      },
+    });
+  }
+
+  handleDraftKeydown(evt) {
+    // the enclosing view treats space and k as play/pause shortcuts
+    evt.stopPropagation();
+
+    if (!this.state.markerDraft) return;
+
+    if (evt.key === 'Enter') {
+      const { t, label } = this.state.markerDraft;
+      this.graph.addMarker(t, label.trim());
+      this.setState({ markerDraft: null });
+      this.redrawIfPaused();
+    } else if (evt.key === 'Escape') {
+      this.setState({ markerDraft: null });
+    }
   }
 
   renderGraph() {
@@ -71,10 +148,15 @@ class GraphCanvas extends React.Component {
   }
 
   render() {
+    const { markerDraft } = this.state;
+
     return (
       <div className="flex-center h-full">
         <div
-          className={`${this.state.graphEmpty ? 'hidden' : ''} h-full w-full`}
+          className={`${
+            this.state.graphEmpty ? 'hidden' : ''
+          } relative h-full w-full cursor-crosshair`}
+          onClick={this.handleClick}
         >
           <AutoFitCanvas
             ref={this.canvasRef}
@@ -83,6 +165,26 @@ class GraphCanvas extends React.Component {
                 this.graph.render(this.props.pausedTime);
             }}
           />
+          {markerDraft && (
+            <input
+              // remount on a new spot so that autoFocus fires again
+              key={`${markerDraft.x},${markerDraft.y}`}
+              autoFocus
+              className="absolute z-10 w-32 cursor-text rounded border border-gray-300 bg-white px-1 text-sm text-gray-900 shadow dark:border-slate-500 dark:bg-slate-700 dark:text-slate-100"
+              style={{ left: markerDraft.x, top: markerDraft.y }}
+              value={markerDraft.label}
+              placeholder="Marker label"
+              onChange={(evt) =>
+                this.setState({
+                  markerDraft: { ...markerDraft, label: evt.target.value },
+                })
+              }
+              onKeyDown={this.handleDraftKeydown}
+              onBlur={() => this.setState({ markerDraft: null })}
+              // the enclosing div turns clicks into new markers
+              onClick={(evt) => evt.stopPropagation()}
+            />
+          )}
         </div>
         <div className="flex-center pointer-events-none absolute top-0 left-0 h-full w-full">
           {this.state.graphEmpty && (
@@ -94,8 +196,13 @@ class GraphCanvas extends React.Component {
   }
 }
 
+GraphCanvas.defaultProps = {
+  markers: [],
+};
+
 GraphCanvas.propTypes = {
   data: PropTypes.arrayOf(PropTypes.any).isRequired,
+  markers: PropTypes.arrayOf(PropTypes.any),
   options: PropTypes.object.isRequired,
   paused: PropTypes.bool.isRequired,
   pausedTime: PropTypes.number.isRequired,

--- a/client/src/components/views/GraphView/GraphView.tsx
+++ b/client/src/components/views/GraphView/GraphView.tsx
@@ -128,6 +128,16 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
   }
 
   handleDocumentKeydown(evt: KeyboardEvent) {
+    // this listener is native and sits below the React root, so a synthetic
+    // stopPropagation() from a field inside the view lands too late to help
+    const target = evt.target;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement
+    ) {
+      return;
+    }
+
     if (evt.code === 'Space' || evt.key === 'k') {
       this.setState({
         ...this.state,
@@ -218,6 +228,14 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
         }),
     ]);
 
+    // markers sent from robot code share their packet's timestamp
+    const markers = this.props.telemetry.flatMap((packet) =>
+      (packet.markers ?? []).map((label) => ({
+        t: packet.timestamp,
+        label,
+      })),
+    );
+
     return (
       <BaseView
         className="flex flex-col overflow-auto"
@@ -271,6 +289,9 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
                 <p className="my-2 text-center">
                   Press the upper-right button to graph selected keys over time
                 </p>
+                <p className="my-2 text-center text-sm opacity-75">
+                  Click the graph to mark a spot; click a marker to remove it
+                </p>
                 <h3 className="mt-6 font-medium">Telemetry to graph:</h3>
                 <div className="ml-3">
                   <MultipleCheckbox
@@ -318,6 +339,7 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
               {({ isDarkMode }) => (
                 <GraphCanvas
                   data={graphData}
+                  markers={markers}
                   options={{
                     windowMs: this.state.windowMs.valid
                       ? this.state.windowMs.value
@@ -328,6 +350,9 @@ class GraphView extends Component<GraphViewProps, GraphViewState> {
                     textColor: isDarkMode
                       ? colors.slate[100]
                       : colors.gray[900],
+                    markerColor: isDarkMode
+                      ? colors.slate[300]
+                      : colors.gray[600],
                   }}
                   paused={this.state.userPaused || this.state.opmodePaused}
                   pausedTime={this.state.pausedTime}

--- a/client/src/store/types/telemetry.ts
+++ b/client/src/store/types/telemetry.ts
@@ -74,6 +74,8 @@ export type TelemetryItem = {
     ops: DrawOp[];
   };
   log: string[];
+  // labels for the packet's instant in time; absent on packets from older apps
+  markers?: string[];
   timestamp: number;
 };
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -26,6 +26,16 @@ packet.fieldOverlay()
 
 Check out [this page](fieldview) for more information on Field View drawing.
 
+Packets can also label their instant in time with `addMarker()`. Markers appear as labeled vertical lines in the Graph View, which makes it easy to line up events in the code with the data around them.
+
+```java
+if (intake.justStarted()) {
+    packet.addMarker("intake on");
+}
+```
+
+Markers can be placed from the client as well: click anywhere on a graph, type a label, and press enter. Clicking a marker removes it. Markers are anchored to a moment in telemetry time, so they scroll along with the data and disappear once they leave the graph window.
+
 Use `FtcDashboard#sendTelemetryPacket()` to dispatch complete packets.
 
 ```java


### PR DESCRIPTION
Labeled vertical lines on the Graph View, so events in the code can be lined up against the data around them instead of eyeballing timestamps.

Features:

- TelemetryPacket#addMarker() marks the instant of a packet from robot code, mirroring the existing addLine()/clearLines() pair
- Click anywhere on a running graph to drop a marker, type a label, and press enter; escape cancels and clicking a marker removes it
- Markers are anchored in telemetry time, so they scroll with the data, honor the window setting, and expire off the left edge like samples do
- Marker color follows the light/dark theme, and labels read bottom-to-top so they stay legible on narrow graphs

Markers ride along on the existing telemetry path rather than introducing a new message type or reducer: they serialize as a markers list beside log, and the packet timestamp supplies the time. The client field is optional, so packets from older apps still parse.

Also fixes the play/pause shortcut firing while typing in a text field. The listener is native and attached below the React root, so a synthetic stopPropagation() from a field inside the view lands too late; it now ignores events originating in an input. This was already reachable before this PR by typing a space in the "Window (ms)" box.

The mock server's sine wave op mode emits a "rising zero" marker on each upward zero crossing, for testing without an app.

https://github.com/user-attachments/assets/f7ec8f8a-d673-4c96-b591-328548952120

