### PR TITLE
Add a search filter to the Telemetry view

### DIFF
--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestDashboardInstance.java
@@ -273,6 +273,14 @@ public class TestDashboardInstance {
         currentPacket.put(x, o);
     }
 
+    public void addLine(String line) {
+        if (currentPacket == null) {
+            currentPacket = new TelemetryPacket();
+        }
+
+        currentPacket.addLine(line);
+    }
+
     public void update() {
         if (currentPacket != null) {
             core.sendTelemetryPacket(currentPacket);

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestTelemetryOpMode.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/TestTelemetryOpMode.java
@@ -1,0 +1,44 @@
+package com.acmerobotics.dashboard;
+
+import com.acmerobotics.dashboard.testopmode.TestOpMode;
+
+public class TestTelemetryOpMode extends TestOpMode {
+    TestDashboardInstance dashboard;
+    public static double AMPLITUDE = 1;
+    public static double PHASE = 90;
+    public static double FREQUENCY = 0.25;
+
+    public TestTelemetryOpMode() {
+        super("TestTelemetryOpMode");
+    }
+
+    @Override
+    protected void init() {
+        dashboard = TestDashboardInstance.getInstance();
+    }
+
+    @Override
+    protected void loop() throws InterruptedException {
+        double phase = 2 * Math.PI * FREQUENCY * (System.currentTimeMillis() / 1000d)
+            + Math.toRadians(PHASE);
+        double x = AMPLITUDE * Math.sin(phase);
+        double y = AMPLITUDE * Math.cos(phase);
+
+        dashboard.addData("x", x);
+        dashboard.addData("y", y);
+        dashboard.addData("heading", 180 * x);
+        dashboard.addData("frontLeftMotorPower", 0.5 * x);
+        dashboard.addData("frontRightMotorPower", -0.5 * x);
+        dashboard.addData("backLeftMotorPower", 0.5 * y);
+        dashboard.addData("backRightMotorPower", -0.5 * y);
+        dashboard.addData("armPosition", Math.round(1000 * x));
+        dashboard.addData("clawOpen", x > 0);
+        dashboard.addData("batteryVoltage", 12.4 + 0.1 * y);
+
+        dashboard.addLine("INFO: drive train nominal");
+        dashboard.addLine(x > 0 ? "armPosition reached target" : "armPosition retracting");
+
+        dashboard.update();
+        Thread.sleep(10);
+    }
+}

--- a/DashboardCore/src/test/java/com/acmerobotics/dashboard/testopmode/TestOpModeManager.java
+++ b/DashboardCore/src/test/java/com/acmerobotics/dashboard/testopmode/TestOpModeManager.java
@@ -3,12 +3,16 @@ package com.acmerobotics.dashboard.testopmode;
 import com.acmerobotics.dashboard.SendFun;
 import com.acmerobotics.dashboard.TestFieldVersatilityOpMode;
 import com.acmerobotics.dashboard.TestSineWaveOpMode;
+import com.acmerobotics.dashboard.TestTelemetryOpMode;
 import java.util.Arrays;
 import java.util.List;
 
 public class TestOpModeManager {
     private final List<TestOpMode> testOpModes =
-        Arrays.asList(new TestSineWaveOpMode(), new TestFieldVersatilityOpMode());
+        Arrays.asList(
+            new TestSineWaveOpMode(),
+            new TestFieldVersatilityOpMode(),
+            new TestTelemetryOpMode());
     private TestOpMode activeOpMode = null;
 
     SendFun sendFun;

--- a/client/src/components/views/TelemetryView.tsx
+++ b/client/src/components/views/TelemetryView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import BaseView, {
@@ -11,12 +11,32 @@ import { RootState } from '@/store/reducers';
 
 type TelemetryViewProps = BaseViewProps & BaseViewHeadingProps;
 
+// Incoming packets rewrite the rendered lines several times a second, which
+// clears any selection sitting inside them. Updates are held while the user has
+// one touching the view so that ordinary copy and paste works; they resume with
+// the next packet once the selection collapses.
+function hasSelectionIn(node: HTMLElement | null) {
+  if (node === null) return false;
+
+  const selection = window.getSelection();
+  if (selection === null || selection.isCollapsed) return false;
+
+  for (let i = 0; i < selection.rangeCount; i++) {
+    if (selection.getRangeAt(i).intersectsNode(node)) return true;
+  }
+
+  return false;
+}
+
 const TelemetryView = ({
   isDraggable = false,
   isUnlocked = false,
 }: TelemetryViewProps) => {
   const [log, setLog] = useState<string[]>([]);
   const [data, setData] = useState<{ [key: string]: string }>({});
+  const [filter, setFilter] = useState('');
+
+  const bodyRef = useRef<HTMLDivElement>(null);
 
   const packets = useSelector((state: RootState) => state.telemetry);
   useEffect(() => {
@@ -25,6 +45,8 @@ const TelemetryView = ({
       setData({});
       return;
     }
+
+    if (hasSelectionIn(bodyRef.current)) return;
 
     setLog((prevLog) =>
       packets.reduce(
@@ -45,23 +67,46 @@ const TelemetryView = ({
     );
   }, [packets]);
 
-  const telemetryLines = Object.keys(data).map((key) => (
-    <span
-      key={key}
-      dangerouslySetInnerHTML={{ __html: `${key}: ${data[key]}<br />` }}
-    />
-  ));
+  const query = filter.trim().toLowerCase();
+  const matches = (text: string) =>
+    query === '' || text.toLowerCase().includes(query);
 
-  const telemetryLog = log.map((line, i) => (
-    <span key={i} dangerouslySetInnerHTML={{ __html: `${line}<br />` }} />
-  ));
+  const telemetryLines = Object.keys(data)
+    .filter(matches)
+    .map((key) => (
+      <span
+        key={key}
+        dangerouslySetInnerHTML={{ __html: `${key}: ${data[key]}<br />` }}
+      />
+    ));
+
+  const telemetryLog = log
+    .filter(matches)
+    .map((line, i) => (
+      <span key={i} dangerouslySetInnerHTML={{ __html: `${line}<br />` }} />
+    ));
 
   return (
     <BaseView isUnlocked={isUnlocked}>
-      <BaseViewHeading isDraggable={isDraggable}>Telemetry</BaseViewHeading>
+      <div className="flex items-center">
+        <BaseViewHeading isDraggable={isDraggable}>Telemetry</BaseViewHeading>
+        <input
+          className="mr-4 w-20 shrink-0 rounded border-0 bg-gray-100 px-2 py-0.5 text-sm transition-all placeholder:text-gray-400 focus:w-32 focus:ring-1 focus:ring-primary-500 dark:bg-slate-800 dark:text-slate-200 dark:placeholder:text-slate-500"
+          type="text"
+          placeholder="Filter"
+          aria-label="Filter telemetry"
+          value={filter}
+          onChange={(evt) => setFilter(evt.target.value)}
+          onKeyDown={(evt) => {
+            if (evt.key === 'Escape') setFilter('');
+          }}
+        />
+      </div>
       <BaseViewBody>
-        <p>{telemetryLines}</p>
-        <p>{telemetryLog}</p>
+        <div ref={bodyRef}>
+          <p>{telemetryLines}</p>
+          <p>{telemetryLog}</p>
+        </div>
       </BaseViewBody>
     </BaseView>
   );


### PR DESCRIPTION
A search box in the Telemetry view header that filters telemetry by label, and a fix that makes telemetry text selectable and copyable while an op mode is running.

 Features:
 - Filters addData entries by key and log lines by their text, case-insensitively
 - Escape clears the box; an empty box renders exactly what the view rendered before
 - Sits in the existing header row and expands on focus, so the view loses no vertical space

Copying telemetry used to be effectively impossible: every packet rewrites the rendered lines, which drops any in-progress selection about twenty times a second. TelemetryView now holds its state while a selection touches the view and resumes with the next packet once the selection collapses. The check is one getSelection() plus a Range.intersectsNode() per packet — 0.6 µs against a 50 ms packet interval — and nothing changes on the robot side, so loop times are unaffected.

Also adds TestTelemetryOpMode to the test server, which publishes a spread of realistically named values and log lines so the filter has something to work on. TestSineWaveOpMode is unchanged; this only needed a small addLine helper on TestDashboardInstance alongside the existing addData.

https://github.com/user-attachments/assets/81ca907d-c383-4073-b7dc-6808d6ee1b7f